### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/steelseriesgg-rs/security/code-scanning/7](https://github.com/Ven0m0/steelseriesgg-rs/security/code-scanning/7)

To fix this, add an explicit `permissions` block that grants only read access to repository contents, since all jobs only need to check out and read code. The simplest and least invasive change is to define this at the workflow root so it applies to all jobs (`fmt`, `clippy`, `test`, and `build`) without modifying each job separately.

Concretely, in `.github/workflows/ci.yml`, insert a top-level `permissions:` section after the `on:` block (around line 10), with `contents: read`. This does not change any functional behavior of the Rust toolchain, caching, build, or test steps; it only limits the `GITHUB_TOKEN` that GitHub Actions injects into the jobs. No additional imports, actions, or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
