### PR TITLE
style: Format Rust code and fix syntax errors

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -17,13 +17,17 @@ use pulse::PulseHandler;
 #[cfg(feature = "sonar")]
 pub use sonar::{SonarChannel, SonarClient};
 
+use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::{Error, Result};
 
 // Channel types are used by both audio and sonar features
 #[cfg(any(feature = "audio", feature = "sonar"))]
 /// Audio channel identifier.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum Channel {
+    /// Master volume
+    Master,
     /// Game audio
     Game,
     /// Voice chat audio
@@ -495,16 +499,5 @@ impl AudioRouter {
 impl Default for AudioRouter {
     fn default() -> Self {
         Self::new()
-#[cfg(feature = "audio")]
-pub mod pulse;
-#[cfg(feature = "sonar")]
-pub mod sonar;
-
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "audio")]
-use pulse::PulseHandler;
-#[cfg(feature = "sonar")]
-pub use sonar::{SonarChannel, SonarClient};
     }
 }

--- a/src/devices/discovery.rs
+++ b/src/devices/discovery.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, info, warn};
 
 use super::headsets::{GenericHeadset, Headset};
@@ -10,7 +10,7 @@ use super::keyboards::apex::Apex3Tkl;
 use super::keyboards::apex_pro_tkl_2023::ApexProTkl2023;
 use super::keyboards::{GenericKeyboard, Keyboard};
 use super::product_ids::{APEX_3_TKL, APEX_PRO_TKL_2023};
-use super::{device_name_from_product_id, device_type_from_product_id, DeviceInfo, DeviceType};
+use super::{DeviceInfo, DeviceType, device_name_from_product_id, device_type_from_product_id};
 use crate::{Error, Result, STEELSERIES_VENDOR_ID};
 
 /// Device fingerprint for tracking devices across disconnections


### PR DESCRIPTION
- Fixed missing Channel enum declaration in src/audio/mod.rs
- Added Master variant to Channel enum
- Removed duplicate code block at end of audio/mod.rs
- Reordered imports according to rustfmt conventions
- Applied cargo fmt --all for consistent code formatting

Note: Unable to run cargo clippy in current environment due to missing system dependencies (libudev-dev). Clippy checks should be run in a properly configured build environment.

https://claude.ai/code/session_011WUexrHj8TnfS9oGH2cG9U

## Summary

## Changes
- 

## Testing
- [ ] Not run (explain)
- [ ] Tests run: 

## Checklist
- [ ] Scope is focused and related issues are linked
- [ ] Documentation updated if needed
- [ ] Tests added or updated where applicable
- [ ] No secrets or sensitive data included
