### PR TITLE
Fix CI failure: Format src/audio/sonar.rs

### DIFF
--- a/src/audio/sonar.rs
+++ b/src/audio/sonar.rs
@@ -533,8 +533,7 @@ impl SonarClient {
                         if attempt == MAX_RETRIES {
                             return Err(Error::Audio(format!(
                                 "GET request failed after {} retries: {}",
-                                MAX_RETRIES,
-                                e
+                                MAX_RETRIES, e
                             )));
                         }
                     } else {
@@ -583,8 +582,7 @@ impl SonarClient {
                         if attempt == MAX_RETRIES {
                             return Err(Error::Audio(format!(
                                 "PUT request failed after {} retries: {}",
-                                MAX_RETRIES,
-                                e
+                                MAX_RETRIES, e
                             )));
                         }
                     } else {


### PR DESCRIPTION
Fixes CI failure caused by formatting violations in `src/audio/sonar.rs`.
The previous commit introduced syntax-valid but unformatted code in the Sonar client implementation.
This change applies `cargo fmt` to resolve the check failure.
Verified locally with full CI suite reproduction (fmt, clippy, test).

---
*PR created automatically by Jules for task [8276201220595902697](https://jules.google.com/task/8276201220595902697) started by @Ven0m0*