### PR TITLE
Fix CI failure: Unused imports in audio module when using sonar feature

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -17,8 +17,10 @@ use pulse::PulseHandler;
 #[cfg(feature = "sonar")]
 pub use sonar::{SonarChannel, SonarClient};
 
+#[cfg(feature = "audio")]
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "audio")]
 use std::collections::HashMap;
 
 // Channel types are used by both audio and sonar features


### PR DESCRIPTION
Fix unused import warnings in `src/audio/mod.rs` that were causing CI failures when running with specific feature combinations (specifically `sonar` enabled but `audio` disabled). This ensures the build passes in all configurations.

---
*PR created automatically by Jules for task [2808850685284497785](https://jules.google.com/task/2808850685284497785) started by @Ven0m0*