### PR TITLE
Fix unused imports in audio module when sonar feature is enabled

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -17,8 +17,10 @@ use pulse::PulseHandler;
 #[cfg(feature = "sonar")]
 pub use sonar::{SonarChannel, SonarClient};
 
+#[cfg(feature = "audio")]
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "audio")]
 use std::collections::HashMap;
 
 // Channel types are used by both audio and sonar features


### PR DESCRIPTION
Guarded `Error`, `Result`, and `HashMap` imports in `src/audio/mod.rs` with `#[cfg(feature = "audio")]` to prevent unused import warnings when compiling with `sonar` feature enabled but `audio` feature disabled. This resolves the remaining CI failure.

---
*PR created automatically by Jules for task [14210902788216864069](https://jules.google.com/task/14210902788216864069) started by @Ven0m0*