### PR TITLE
Fix CI failure: Unused imports in audio module

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -17,8 +17,10 @@ use pulse::PulseHandler;
 #[cfg(feature = "sonar")]
 pub use sonar::{SonarChannel, SonarClient};
 
+#[cfg(feature = "audio")]
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "audio")]
 use std::collections::HashMap;
 
 // Channel types are used by both audio and sonar features


### PR DESCRIPTION
Fixes CI failure due to unused imports in `src/audio/mod.rs` when `sonar` feature is enabled without `audio`.

---
*PR created automatically by Jules for task [3195943770228350275](https://jules.google.com/task/3195943770228350275) started by @Ven0m0*