### PR TITLE
Fix CI syntax errors and unused code in performance module

### DIFF
--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -113,7 +113,6 @@ pub trait Device: Send + Sync {
     }
 }
 
-/// Report cache entry for deduplication.
 #[derive(Debug)]
 /// HID communication optimizer for reducing CPU usage.
 pub struct HidOptimizer {

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -223,13 +223,6 @@ impl PerformanceMonitor {
         let base_interval_ms = self.current_complexity.frame_budget_ms();
 
         // Analyze recent performance to detect system load
-        let _avg_frame_time = if !self.timing_history.is_empty() {
-            let sum: Duration = self.timing_history.iter().sum();
-            sum.as_secs_f32() * 1000.0 / self.timing_history.len() as f32
-        } else {
-            base_interval_ms
-        };
-
         let avg_computation_time = if !self.computation_history.is_empty() {
             let sum: Duration = self.computation_history.iter().sum();
             sum.as_micros() as f32 / (self.computation_history.len() as f32 * 1000.0) // Convert to ms


### PR DESCRIPTION
This change fixes CI failures by:
1. Removing unused variable `_avg_frame_time` calculation in `src/performance.rs` which was causing a warning (treated as error in CI) and potentially referencing a removed field `timing_history`.
2. Fixing a malformed doc comment block in `src/devices/mod.rs` where a redundant doc comment was placed before `#[derive(Debug)]`.

These changes address the reported syntax errors and warnings that were blocking the build.

---
*PR created automatically by Jules for task [1653792300541924195](https://jules.google.com/task/1653792300541924195) started by @Ven0m0*