### PR TITLE
Fix CI formatting failure in src/audio/sonar.rs

### DIFF
--- a/src/audio/sonar.rs
+++ b/src/audio/sonar.rs
@@ -533,8 +533,7 @@ impl SonarClient {
                         if attempt == MAX_RETRIES {
                             return Err(Error::Audio(format!(
                                 "GET request failed after {} retries: {}",
-                                MAX_RETRIES,
-                                e
+                                MAX_RETRIES, e
                             )));
                         }
                     } else {
@@ -583,8 +582,7 @@ impl SonarClient {
                         if attempt == MAX_RETRIES {
                             return Err(Error::Audio(format!(
                                 "PUT request failed after {} retries: {}",
-                                MAX_RETRIES,
-                                e
+                                MAX_RETRIES, e
                             )));
                         }
                     } else {


### PR DESCRIPTION
Fixed formatting issues in `src/audio/sonar.rs` that were causing the CI `fmt` job to fail.
Ran `cargo fmt` to apply the project's standard formatting.
Verified that `cargo fmt --all -- --check`, `cargo test`, and `cargo clippy` all pass locally.

---
*PR created automatically by Jules for task [4973021354018269508](https://jules.google.com/task/4973021354018269508) started by @Ven0m0*