### PR TITLE
fix: resolve duplicate import and async trait compilation errors

### DIFF
--- a/src/devices/discovery.rs
+++ b/src/devices/discovery.rs
@@ -13,7 +13,6 @@ use super::keyboards::{GenericKeyboard, Keyboard};
 use super::product_ids::{APEX_3_TKL, APEX_PRO_TKL_2023};
 use super::{DeviceInfo, DeviceType, device_name_from_product_id, device_type_from_product_id};
 use crate::{Error, Result, STEELSERIES_VENDOR_ID};
-use hidapi::HidApi;
 
 /// Device fingerprint for tracking devices across disconnections
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/devices/keyboards/apex.rs
+++ b/src/devices/keyboards/apex.rs
@@ -205,8 +205,8 @@ impl Keyboard for Apex3Tkl {
         self.inner.trigger_key_reactive(keys, duration).await
     }
 
-    fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
-        self.inner.apply_per_key_effect_with_brightness(brightness)
+    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
+        self.inner.apply_per_key_effect_with_brightness(brightness).await
     }
 
     async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> {

--- a/src/devices/keyboards/apex_pro_tkl_2023.rs
+++ b/src/devices/keyboards/apex_pro_tkl_2023.rs
@@ -178,8 +178,8 @@ impl Keyboard for ApexProTkl2023 {
         self.inner.trigger_key_reactive(keys, duration).await
     }
 
-    fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
-        self.inner.apply_per_key_effect_with_brightness(brightness)
+    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
+        self.inner.apply_per_key_effect_with_brightness(brightness).await
     }
 
     async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> {

--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -668,7 +668,7 @@ impl Keyboard for GenericKeyboard {
         }
     }
 
-    fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
+    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
         let key_colors = if let Some(ref mut controller) = self.per_key_controller {
             controller.set_brightness(brightness.clamp(0.0, 1.0));
 


### PR DESCRIPTION
I have fixed the compilation errors that were causing the CI to fail.

Changes:
1.  **`src/devices/discovery.rs`**: Removed a duplicate `use hidapi::HidApi;` statement.
2.  **`src/devices/keyboards/mod.rs`**: Changed `apply_per_key_effect_with_brightness` to `async fn` in `GenericKeyboard` implementation.
3.  **`src/devices/keyboards/apex.rs`**: Changed `apply_per_key_effect_with_brightness` to `async fn` and awaited the inner call.
4.  **`src/devices/keyboards/apex_pro_tkl_2023.rs`**: Changed `apply_per_key_effect_with_brightness` to `async fn` and awaited the inner call.

Verification:
-   Ran `cargo check` successfully.
-   Ran `cargo check --features sonar,audio` successfully.
-   Ran `cargo test` successfully.
-   Ran `cargo fmt --check` successfully.

---
*PR created automatically by Jules for task [5556456929643902054](https://jules.google.com/task/5556456929643902054) started by @Ven0m0*