### PR TITLE
Fix GameSense server CORS vulnerability

### DIFF
--- a/src/audio/sonar.rs
+++ b/src/audio/sonar.rs
@@ -514,31 +514,24 @@ impl SonarClient {
                 tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
             }
 
-            let response = match self.client.get(url).send().await {
-                Ok(r) => r,
-                Err(e) => {
-                    if Self::is_transient_error(&e) && attempt < MAX_RETRIES {
-                        continue;
+            match self.client.get(url).send().await {
+                Ok(response) => {
+                    if !response.status().is_success() {
+                        return Err(Error::Audio(format!(
+                            "GET request failed with status: {}",
+                            response.status()
+                        )));
                     }
-
                     return response
                         .json()
                         .await
                         .map_err(|e| Error::Audio(format!("Failed to parse response: {}", e)));
                 }
                 Err(e) => {
-                    if Self::is_transient_error(&e) {
-                        if attempt == MAX_RETRIES {
-                            return Err(Error::Audio(format!(
-                                "GET request failed after {} retries: {}",
-                                MAX_RETRIES, e
-                            )));
-                        }
-                    } else {
-                        return Err(Error::Audio(format!("GET request failed: {}", e)));
+                    if Self::is_transient_error(&e) && attempt < MAX_RETRIES {
+                        continue;
                     }
-
-                    // Continue to next attempt if transient error and retries remaining
+                    return Err(Error::Audio(format!("GET request failed: {}", e)));
                 }
             }
         }
@@ -572,7 +565,7 @@ impl SonarClient {
                     if Self::is_transient_error(&e) && attempt < MAX_RETRIES {
                         continue;
                     }
-                    // Continue to next attempt if transient error and retries remaining
+                    return Err(Error::Audio(format!("PUT request failed: {}", e)));
                 }
             }
         }

--- a/src/devices/discovery.rs
+++ b/src/devices/discovery.rs
@@ -13,7 +13,6 @@ use super::keyboards::{GenericKeyboard, Keyboard};
 use super::product_ids::{APEX_3_TKL, APEX_PRO_TKL_2023};
 use super::{DeviceInfo, DeviceType, device_name_from_product_id, device_type_from_product_id};
 use crate::{Error, Result, STEELSERIES_VENDOR_ID};
-use hidapi::HidApi;
 
 /// Device fingerprint for tracking devices across disconnections
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/devices/keyboards/apex.rs
+++ b/src/devices/keyboards/apex.rs
@@ -205,8 +205,8 @@ impl Keyboard for Apex3Tkl {
         self.inner.trigger_key_reactive(keys, duration).await
     }
 
-    fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
-        self.inner.apply_per_key_effect_with_brightness(brightness)
+    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
+        self.inner.apply_per_key_effect_with_brightness(brightness).await
     }
 
     async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> {

--- a/src/devices/keyboards/apex_pro_tkl_2023.rs
+++ b/src/devices/keyboards/apex_pro_tkl_2023.rs
@@ -178,8 +178,8 @@ impl Keyboard for ApexProTkl2023 {
         self.inner.trigger_key_reactive(keys, duration).await
     }
 
-    fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
-        self.inner.apply_per_key_effect_with_brightness(brightness)
+    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
+        self.inner.apply_per_key_effect_with_brightness(brightness).await
     }
 
     async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> {

--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -668,7 +668,7 @@ impl Keyboard for GenericKeyboard {
         }
     }
 
-    fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
+    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
         let key_colors = if let Some(ref mut controller) = self.per_key_controller {
             controller.set_brightness(brightness.clamp(0.0, 1.0));
 

--- a/src/gamesense/server.rs
+++ b/src/gamesense/server.rs
@@ -3,14 +3,14 @@
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderValue, Method, StatusCode, header},
     routing::{get, post},
 };
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{debug, info};
 
 use super::*;
@@ -88,7 +88,18 @@ impl GameSenseServer {
             .route("/remove_game_event", post(remove_event))
             // Info endpoint
             .route("/", get(server_info))
-            .layer(CorsLayer::permissive())
+            .layer(
+                CorsLayer::new()
+                    .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                    .allow_headers([header::CONTENT_TYPE])
+                    .allow_origin(AllowOrigin::predicate(|origin: &HeaderValue, _parts: &_| {
+                        let origin_bytes = origin.as_bytes();
+                        origin_bytes.starts_with(b"http://localhost")
+                            || origin_bytes.starts_with(b"https://localhost")
+                            || origin_bytes.starts_with(b"http://127.0.0.1")
+                            || origin_bytes.starts_with(b"https://127.0.0.1")
+                    })),
+            )
             .with_state(state)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1845,7 +1845,7 @@ async fn cmd_performance(manager: &DeviceManager, action: PerformanceAction) -> 
                         export_performance_stats(manager, &keyboards, output_path, json)?;
                     }
 
-tokio::time::sleep(Duration::from_secs(interval_seconds)).await;
+                    tokio::time::sleep(Duration::from_secs(interval_seconds)).await;
                 }
             } else {
                 display_performance_stats(manager, &keyboards, json)?;

--- a/tests/cors_security.rs
+++ b/tests/cors_security.rs
@@ -1,0 +1,81 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use steelseries_gg::gamesense::GameSenseServer;
+use tokio::net::TcpListener;
+
+#[tokio::test]
+#[ignore]
+async fn test_cors_vulnerability() {
+    println!("Starting test_cors_vulnerability");
+    // Bind to port 0 to get a free port
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    println!("Selected port: {}", port);
+
+    let server = GameSenseServer::new("127.0.0.1", port).unwrap();
+
+    tokio::spawn(async move {
+        println!("Server task started");
+        if let Err(e) = server.run().await {
+            eprintln!("Server error: {}", e);
+        }
+    });
+
+    // Wait for server to start
+    let mut attempts = 0;
+    loop {
+        if TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok() {
+            println!("Connected to server!");
+            break;
+        }
+        attempts += 1;
+        if attempts > 50 {
+            panic!("Server failed to start");
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    // 1. Test with Evil Origin
+    println!("Sending evil request...");
+    let request = format!(
+        "POST /game_metadata HTTP/1.1\r\n         Host: 127.0.0.1:{}\r\n         Origin: http://evil.com\r\n         Content-Type: application/json\r\n         Content-Length: 2\r\n         Connection: close\r\n         \r\n         {{}}",
+        port
+    );
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    println!("Response from evil.com origin:\n{}", response);
+
+    let allows_evil = response
+        .to_lowercase()
+        .contains("access-control-allow-origin: http://evil.com")
+        || response.to_lowercase().contains("access-control-allow-origin: *");
+
+    if allows_evil {
+        panic!("SECURITY FAILURE: Server allowed CORS request from http://evil.com");
+    }
+
+    // 2. Test with Localhost Origin
+    println!("Sending localhost request...");
+    let request_local = format!(
+        "POST /game_metadata HTTP/1.1\r\n         Host: 127.0.0.1:{}\r\n         Origin: http://localhost:{}\r\n         Content-Type: application/json\r\n         Content-Length: 2\r\n         Connection: close\r\n         \r\n         {{}}",
+        port, port
+    );
+
+    let mut stream_local = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    stream_local.write_all(request_local.as_bytes()).unwrap();
+
+    let mut response_local = String::new();
+    stream_local.read_to_string(&mut response_local).unwrap();
+
+    println!("Response from localhost origin:\n{}", response_local);
+
+    let allows_local = response_local.to_lowercase().contains("access-control-allow-origin");
+    // Assert strictly
+    assert!(allows_local, "Server should allow localhost origin");
+}


### PR DESCRIPTION
This change replaces the permissive CORS configuration (`CorsLayer::permissive()`) in the GameSense server with a strict policy that only allows requests from `http://localhost` and `http://127.0.0.1`. This prevents malicious websites from accessing the local GameSense server and manipulating device lighting or game events.

Also fixed several pre-existing compilation errors and logic issues in the codebase to enable running tests and CI checks:
- Fixed duplicate import in `src/devices/discovery.rs`
- Fixed async trait implementation in `src/devices/keyboards/*.rs`
- Fixed logic error and syntax in `src/audio/sonar.rs` retry loop
- Added `tests/cors_security.rs` to verify the vulnerability (ignored in CI due to environment constraints)

---
*PR created automatically by Jules for task [4697007109790974385](https://jules.google.com/task/4697007109790974385) started by @Ven0m0*