### PR TITLE
Implement Error Logging in Bug Reports

### DIFF
--- a/src/diagnostics_export.rs
+++ b/src/diagnostics_export.rs
@@ -100,12 +100,44 @@ impl From<&DeviceInfo> for DeviceInfoSummary {
 }
 
 /// Error log entry (placeholder for future error tracking).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorLog {
     /// Error timestamp
     pub timestamp: DateTime<Utc>,
     /// Error message
     pub message: String,
+}
+
+/// Global error log to keep track of recent errors.
+static GLOBAL_ERROR_LOG: std::sync::OnceLock<parking_lot::Mutex<Vec<ErrorLog>>> = std::sync::OnceLock::new();
+
+/// Maximum number of errors to keep in the global log.
+const MAX_ERROR_LOGS: usize = 100;
+
+/// Record a new error message in the global error log.
+pub fn record_error(message: String) {
+    let log_mutex = GLOBAL_ERROR_LOG.get_or_init(|| parking_lot::Mutex::new(Vec::new()));
+    let mut logs = log_mutex.lock();
+
+    logs.push(ErrorLog {
+        timestamp: Utc::now(),
+        message,
+    });
+
+    // Keep only the most recent errors
+    if logs.len() > MAX_ERROR_LOGS {
+        let excess = logs.len() - MAX_ERROR_LOGS;
+        logs.drain(0..excess);
+    }
+}
+
+/// Retrieve a copy of the recent error logs.
+pub fn get_recent_errors() -> Vec<ErrorLog> {
+    if let Some(log_mutex) = GLOBAL_ERROR_LOG.get() {
+        log_mutex.lock().clone()
+    } else {
+        Vec::new()
+    }
 }
 
 /// Collect system information using sysinfo (BLOCKING operation).
@@ -286,8 +318,8 @@ pub async fn collect_bug_report(include_hid_logs: bool, include_performance: boo
         None
     };
 
-    // Placeholder for error logs (future enhancement)
-    let recent_errors = Vec::new();
+    // Fetch recent error logs
+    let recent_errors = get_recent_errors();
 
     Ok(BugReport {
         timestamp: Utc::now(),
@@ -327,4 +359,52 @@ pub async fn export_bug_report(report: &BugReport, path: &str) -> Result<()> {
 
     debug!("Bug report export complete: {} bytes", file_size);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Since GLOBAL_ERROR_LOG is static, tests running in parallel can conflict.
+    // We use a local static Mutex to serialize access to the global error log in tests.
+    static TEST_MUTEX: parking_lot::Mutex<()> = parking_lot::const_mutex(());
+
+    fn clear_global_logs() {
+        if let Some(log_mutex) = GLOBAL_ERROR_LOG.get() {
+            log_mutex.lock().clear();
+        }
+    }
+
+    #[test]
+    fn test_record_and_get_errors() {
+        let _guard = TEST_MUTEX.lock();
+        clear_global_logs();
+
+        record_error("Test error 1".to_string());
+        record_error("Test error 2".to_string());
+
+        let errors = get_recent_errors();
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[0].message, "Test error 1");
+        assert_eq!(errors[1].message, "Test error 2");
+    }
+
+    #[test]
+    fn test_error_log_size_limit() {
+        let _guard = TEST_MUTEX.lock();
+        clear_global_logs();
+
+        // Add more than the limit
+        for i in 0..110 {
+            record_error(format!("Error {}", i));
+        }
+
+        let errors = get_recent_errors();
+        assert_eq!(errors.len(), MAX_ERROR_LOGS);
+
+        // Ensure we kept the most recent ones
+        // Since we insert sequentially, if we had 110 (0..109), the ones kept are 10..109
+        assert_eq!(errors[0].message, "Error 10");
+        assert_eq!(errors[errors.len() - 1].message, "Error 109");
+    }
 }

--- a/update_diagnostics.py
+++ b/update_diagnostics.py
@@ -1,0 +1,118 @@
+import re
+
+with open("src/diagnostics_export.rs", "r") as f:
+    content = f.read()
+
+replacement = """
+/// Error log entry (placeholder for future error tracking).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorLog {
+    /// Error timestamp
+    pub timestamp: DateTime<Utc>,
+    /// Error message
+    pub message: String,
+}
+
+/// Global error log to keep track of recent errors.
+static GLOBAL_ERROR_LOG: std::sync::OnceLock<parking_lot::Mutex<Vec<ErrorLog>>> = std::sync::OnceLock::new();
+
+/// Maximum number of errors to keep in the global log.
+const MAX_ERROR_LOGS: usize = 100;
+
+/// Record a new error message in the global error log.
+pub fn record_error(message: String) {
+    let log_mutex = GLOBAL_ERROR_LOG.get_or_init(|| parking_lot::Mutex::new(Vec::new()));
+    let mut logs = log_mutex.lock();
+
+    logs.push(ErrorLog {
+        timestamp: Utc::now(),
+        message,
+    });
+
+    // Keep only the most recent errors
+    if logs.len() > MAX_ERROR_LOGS {
+        let excess = logs.len() - MAX_ERROR_LOGS;
+        logs.drain(0..excess);
+    }
+}
+
+/// Retrieve a copy of the recent error logs.
+pub fn get_recent_errors() -> Vec<ErrorLog> {
+    if let Some(log_mutex) = GLOBAL_ERROR_LOG.get() {
+        log_mutex.lock().clone()
+    } else {
+        Vec::new()
+    }
+}
+"""
+
+content = re.sub(
+    r"/// Error log entry \(placeholder for future error tracking\).\s*#\[derive\(Debug, Serialize, Deserialize\)\]\s*pub struct ErrorLog \{\s*/// Error timestamp\s*pub timestamp: DateTime<Utc>,\s*/// Error message\s*pub message: String,\s*\}",
+    replacement.strip(),
+    content,
+    flags=re.MULTILINE
+)
+
+# Also update recent_errors assignment
+content = re.sub(
+    r"// Placeholder for error logs \(future enhancement\)\s*let recent_errors = Vec::new\(\);",
+    "// Fetch recent error logs\n    let recent_errors = get_recent_errors();",
+    content
+)
+
+# Fix tests
+replacement_tests = """
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Since GLOBAL_ERROR_LOG is static, tests running in parallel can conflict.
+    // We use a local static Mutex to serialize access to the global error log in tests.
+    static TEST_MUTEX: parking_lot::Mutex<()> = parking_lot::const_mutex(());
+
+    fn clear_global_logs() {
+        if let Some(log_mutex) = GLOBAL_ERROR_LOG.get() {
+            log_mutex.lock().clear();
+        }
+    }
+
+    #[test]
+    fn test_record_and_get_errors() {
+        let _guard = TEST_MUTEX.lock();
+        clear_global_logs();
+
+        record_error("Test error 1".to_string());
+        record_error("Test error 2".to_string());
+
+        let errors = get_recent_errors();
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[0].message, "Test error 1");
+        assert_eq!(errors[1].message, "Test error 2");
+    }
+
+    #[test]
+    fn test_error_log_size_limit() {
+        let _guard = TEST_MUTEX.lock();
+        clear_global_logs();
+
+        // Add more than the limit
+        for i in 0..110 {
+            record_error(format!("Error {}", i));
+        }
+
+        let errors = get_recent_errors();
+        assert_eq!(errors.len(), MAX_ERROR_LOGS);
+
+        // Ensure we kept the most recent ones
+        // Since we insert sequentially, if we had 110 (0..109), the ones kept are 10..109
+        assert_eq!(errors[0].message, "Error 10");
+        assert_eq!(errors[errors.len() - 1].message, "Error 109");
+    }
+}
+"""
+
+if "#[cfg(test)]" not in content:
+    content += "\n" + replacement_tests.strip() + "\n"
+
+with open("src/diagnostics_export.rs", "w") as f:
+    f.write(content)


### PR DESCRIPTION
I have implemented the "error logs" tracking in `BugReport` within `src/diagnostics_export.rs`.
The `BugReport` structure had a `recent_errors: Vec<ErrorLog>` field, which was a placeholder for future error tracking.
I implemented a `GLOBAL_ERROR_LOG` which is a `std::sync::OnceLock<parking_lot::Mutex<Vec<ErrorLog>>>` with a max capacity. 
I created a `record_error` function that limits the maximum amount of recorded error logs.
I created a `get_recent_errors` function that gets the logged errors to include them when exporting a Bug Report.
I added tests to test `record_error` limits and correctness.

---
*PR created automatically by Jules for task [13391876180109610259](https://jules.google.com/task/13391876180109610259) started by @Ven0m0*