### PR TITLE
🔒 Fix local GameSense server CORS origin vulnerability

### DIFF
--- a/src/gamesense/server.rs
+++ b/src/gamesense/server.rs
@@ -97,10 +97,14 @@ impl GameSenseServer {
                     .allow_headers([header::CONTENT_TYPE])
                     .allow_origin(AllowOrigin::predicate(|origin: &HeaderValue, _parts: &_| {
                         let origin_bytes = origin.as_bytes();
-                        origin_bytes.starts_with(b"http://localhost")
-                            || origin_bytes.starts_with(b"https://localhost")
-                            || origin_bytes.starts_with(b"http://127.0.0.1")
-                            || origin_bytes.starts_with(b"https://127.0.0.1")
+                        origin_bytes == b"http://localhost"
+                            || origin_bytes.starts_with(b"http://localhost:")
+                            || origin_bytes == b"https://localhost"
+                            || origin_bytes.starts_with(b"https://localhost:")
+                            || origin_bytes == b"http://127.0.0.1"
+                            || origin_bytes.starts_with(b"http://127.0.0.1:")
+                            || origin_bytes == b"https://127.0.0.1"
+                            || origin_bytes.starts_with(b"https://127.0.0.1:")
                     })),
             )
             .with_state(state)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2893,12 +2893,10 @@ fn apply_saved_poll_rates(config: &Config) {
 
     if let Some(mouse_hz) = config.poll_rate.mouse_hz {
         match PollRate::from_hz(mouse_hz) {
-            Ok(rate) => {
-                match set_poll_rate(DeviceType::Mouse, rate) {
-                    Ok(()) => info!("Applied mouse poll rate: {} Hz", mouse_hz),
-                    Err(e) => tracing::warn!("Failed to set mouse poll rate: {}", e),
-                }
-            }
+            Ok(rate) => match set_poll_rate(DeviceType::Mouse, rate) {
+                Ok(()) => info!("Applied mouse poll rate: {} Hz", mouse_hz),
+                Err(e) => tracing::warn!("Failed to set mouse poll rate: {}", e),
+            },
             Err(e) => {
                 tracing::warn!(
                     "Configured mouse poll rate {} Hz is invalid or unsupported: {}",
@@ -2911,12 +2909,10 @@ fn apply_saved_poll_rates(config: &Config) {
 
     if let Some(keyboard_hz) = config.poll_rate.keyboard_hz {
         match PollRate::from_hz(keyboard_hz) {
-            Ok(rate) => {
-                match set_poll_rate(DeviceType::Keyboard, rate) {
-                    Ok(()) => info!("Applied keyboard poll rate: {} Hz", keyboard_hz),
-                    Err(e) => tracing::warn!("Failed to set keyboard poll rate: {}", e),
-                }
-            }
+            Ok(rate) => match set_poll_rate(DeviceType::Keyboard, rate) {
+                Ok(()) => info!("Applied keyboard poll rate: {} Hz", keyboard_hz),
+                Err(e) => tracing::warn!("Failed to set keyboard poll rate: {}", e),
+            },
             Err(e) => {
                 tracing::warn!(
                     "Configured keyboard poll rate {} Hz is invalid or unsupported: {}",


### PR DESCRIPTION
🎯 **What:** The `CorsLayer` implementation previously used `starts_with("http://localhost")` checks. This insecure origin validation logic allowed bypassing CORS protection via domain spoofing (e.g., `http://localhost.evil.com`). The description says `CorsLayer::permissive()` was used before but we actually updated the `starts_with` validation mechanism to prevent exact-matching bypasses.

⚠️ **Risk:** Any website ending with the specific hostname sequence could bypass CORS and directly interact with the local GameSense SDK HTTP server. Since it controls system hardware behaviors (like RGB lighting on devices and screen handlers), this is an unauthenticated vector.

🛡️ **Solution:** Updated the CORS origin predicate. It now strictly tests for exact match equality (e.g., `origin_bytes == b"http://localhost"`) or the explicit presence of the port delimiter (e.g., `origin_bytes.starts_with(b"http://localhost:")`), guaranteeing that origin domains cannot spoof the validation check.

---
*PR created automatically by Jules for task [10245812889688468215](https://jules.google.com/task/10245812889688468215) started by @Ven0m0*