### PR TITLE
🔒 Fix missing O_NOFOLLOW in profile saving

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "biomejs.biome", 
+    "biomejs.biome",
     "oxc.oxc-vscode",
     "hverlin.mise-vscode",
     "mads-hartmann.bash-ide-vscode",

--- a/src/profiles/mod.rs
+++ b/src/profiles/mod.rs
@@ -212,8 +212,23 @@ impl ProfileManager {
         #[cfg(unix)]
         {
             let mut options = OpenOptions::new();
-            options.write(true).create(true).truncate(true).mode(0o600);
-            let file = options.open(&path)?;
+            options
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .custom_flags(libc::O_NOFOLLOW);
+            let file = match options.open(&path) {
+                Ok(file) => file,
+                Err(err) => {
+                    if err.raw_os_error() == Some(libc::ELOOP) {
+                        return Err(Error::Profile(
+                            "Refusing to write profile because it is (or contains) a symlink".into(),
+                        ));
+                    }
+                    return Err(err.into());
+                }
+            };
             let mut perms = file.metadata()?.permissions();
             perms.set_mode(0o600);
             file.set_permissions(perms)?;

--- a/src/profiles/tests.rs
+++ b/src/profiles/tests.rs
@@ -139,3 +139,31 @@ fn test_secure_profile_permissions() {
     let file_metadata = std::fs::symlink_metadata(&path).unwrap();
     assert_eq!(file_metadata.permissions().mode() & 0o777, 0o600);
 }
+
+#[test]
+#[cfg(unix)]
+fn test_profile_save_refuse_symlink() {
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let profiles_dir = dir.path().join("profiles");
+    std::fs::create_dir_all(&profiles_dir).unwrap();
+
+    let manager = ProfileManager::with_dir(profiles_dir.clone());
+    let profile = Profile::new("symlink_test");
+
+    let target_file = dir.path().join("target.json");
+    std::fs::write(&target_file, "dummy").unwrap();
+
+    let symlink_path = profiles_dir.join("symlink_test.json");
+    symlink(&target_file, &symlink_path).unwrap();
+
+    let result = manager.save(&profile);
+    assert!(result.is_err(), "Expected save to fail when target is a symlink");
+    if let Err(crate::Error::Profile(msg)) = result {
+        assert!(msg.contains("symlink"));
+    } else {
+        panic!("Expected Error::Profile with symlink message, got {:?}", result);
+    }
+}


### PR DESCRIPTION
🎯 What
Added missing `O_NOFOLLOW` flag to the `OpenOptions` used during profile saving on Unix systems.

⚠️ Risk
Prior to this fix, if an attacker replaced a profile configuration file with a symlink (e.g., pointing to a sensitive file like `/etc/shadow`), the program could inadvertently follow that symlink and overwrite the sensitive file.

🛡️ Solution
Used `.custom_flags(libc::O_NOFOLLOW)` to refuse writes to symlinked paths. Specifically, handled `libc::ELOOP` errors during file opening, properly aborting the operation and returning `Error::Profile`. Added `test_profile_save_refuse_symlink` to `src/profiles/tests.rs` to proactively verify that symlinks are rejected.

---
*PR created automatically by Jules for task [16310864657403395912](https://jules.google.com/task/16310864657403395912) started by @Ven0m0*