### PR TITLE
🧹 Refactor: Consolidate duplicate HID command logic in keyboards

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "biomejs.biome", 
+    "biomejs.biome",
     "oxc.oxc-vscode",
     "hverlin.mise-vscode",
     "mads-hartmann.bash-ide-vscode",

--- a/src/devices/keyboards/apex_pro_tkl_2023.rs
+++ b/src/devices/keyboards/apex_pro_tkl_2023.rs
@@ -132,18 +132,7 @@ impl ApexProTkl2023 {
     /// Precision is limited to 0.1mm increments.
     pub fn set_actuation_point_mm(&mut self, mm: f32) -> Result<()> {
         let command = ActuationCommand::from_mm(mm);
-        command.validate()?;
-
-        // Use the new command infrastructure for consistent serialization
-        let report_builder = HidReportBuilder::new(HidDeviceType::Keyboard);
-
-        let mut buffer = [0u8; KEYBOARD_REPORT_SIZE];
-        let size = report_builder.build_report(command.clone(), &mut buffer)?;
-
-        self.inner.send_raw(&buffer[..size])?;
-
-        self.inner.update_cached_actuation_point(command.actuation_point);
-        Ok(())
+        self.set_actuation_point(command.actuation_point)
     }
 
     #[cfg(feature = "experimental-apex-2023")]

--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -276,6 +276,13 @@ impl GenericKeyboard {
     ///
     /// Offloads the blocking hidapi write to `spawn_blocking` so the tokio
     /// worker thread is not stalled during HID I/O.
+    /// Build and send a HID command report to the keyboard asynchronously.
+    async fn send_command_async<C: crate::devices::HidCommand>(&self, command: C) -> Result<()> {
+        let mut buffer = [0u8; crate::devices::KEYBOARD_REPORT_SIZE];
+        let size = self.report_builder.build_report(command, &mut buffer)?;
+        self.send_report_async(&buffer[..size]).await
+    }
+
     async fn send_report_async(&self, data: &[u8]) -> Result<()> {
         use tracing::debug;
 
@@ -360,18 +367,14 @@ impl GenericKeyboard {
             for i in 0..self.zone_color_buffer.len() {
                 let color = self.zone_color_buffer[i];
                 let zone_index = (i + 1) as u8; // zones start at 1, not 0
-                let rgb_command = RgbZoneCommand::new_specific_zone(zone_index, color);
-                let mut buffer = [0u8; super::KEYBOARD_REPORT_SIZE];
-                let size = self.report_builder.build_report(rgb_command, &mut buffer)?;
-                self.send_report_async(&buffer[..size]).await?;
+                self.send_command_async(RgbZoneCommand::new_specific_zone(zone_index, color))
+                    .await?;
             }
             return Ok(());
         }
 
-        let rgb_command = RgbZoneCommand::new_all_zones(&self.zone_color_buffer);
-        let mut buffer = [0u8; super::KEYBOARD_REPORT_SIZE];
-        let size = self.report_builder.build_report(rgb_command, &mut buffer)?;
-        self.send_report_async(&buffer[..size]).await
+        self.send_command_async(RgbZoneCommand::new_all_zones(&self.zone_color_buffer))
+            .await
     }
 
     /// Update the cached actuation point value.
@@ -484,10 +487,7 @@ impl Keyboard for GenericKeyboard {
     }
 
     async fn set_brightness(&mut self, brightness: u8) -> Result<()> {
-        let brightness_command = BrightnessCommand::new(brightness);
-        let mut buffer = [0u8; 65];
-        let size = self.report_builder.build_report(brightness_command, &mut buffer)?;
-        self.send_report_async(&buffer[..size]).await
+        self.send_command_async(BrightnessCommand::new(brightness)).await
     }
 
     async fn apply(&mut self) -> Result<()> {
@@ -540,17 +540,12 @@ impl Keyboard for GenericKeyboard {
             ));
         }
 
-        let command = builder.build();
-        let mut buffer = [0u8; 65];
-        let size = self.report_builder.build_report(command, &mut buffer)?;
-        self.send_report_async(&buffer[..size]).await
+        self.send_command_async(builder.build()).await
     }
 
     async fn set_key_color_direct(&mut self, address: KeyAddress, color: Color) -> Result<()> {
-        let command = PerKeyRgbCommand::single_key(address, color);
-        let mut buffer = [0u8; 65];
-        let size = self.report_builder.build_report(command, &mut buffer)?;
-        self.send_report_async(&buffer[..size]).await
+        self.send_command_async(PerKeyRgbCommand::single_key(address, color))
+            .await
     }
 
     async fn set_key_colors_direct(&mut self, key_colors: &[(KeyAddress, Color)]) -> Result<()> {
@@ -564,10 +559,7 @@ impl Keyboard for GenericKeyboard {
             builder.add_key_matrix(*address, *color);
         }
 
-        let command = builder.build();
-        let mut buffer = [0u8; 65];
-        let size = self.report_builder.build_report(command, &mut buffer)?;
-        self.send_report_async(&buffer[..size]).await
+        self.send_command_async(builder.build()).await
     }
 
     async fn clear_per_key_rgb(&mut self) -> Result<()> {
@@ -607,10 +599,7 @@ impl Keyboard for GenericKeyboard {
             ));
         }
 
-        let command = builder.build();
-        let mut buffer = [0u8; 65];
-        let size = self.report_builder.build_report(command, &mut buffer)?;
-        self.send_report_async(&buffer[..size]).await
+        self.send_command_async(builder.build()).await
     }
 
     // === Zone-based RGB Fallback Implementation ===


### PR DESCRIPTION
🧹 [Code Health] Consolidate duplicate HID command logic in keyboards

🎯 **What:**
- Simplified `set_actuation_point_mm` in `apex_pro_tkl_2023.rs` to reuse the existing report generation inside `set_actuation_point` instead of duplicating it.
- Extracted duplicate HID command assembly logic inside `GenericKeyboard` (in `mod.rs`) into a `send_command_async` helper.

💡 **Why:**
This improves maintainability by removing redundant boilerplate responsible for sizing and copying commands into `buffer` before invoking asynchronous transmit operations. It ensures all commands flow through one central helper method that leverages `self.report_builder.build_report()`.

✅ **Verification:**
Ran `cargo test` and `cargo check` to ensure behavior consistency and type checking.

✨ **Result:**
Reduced code duplication and shortened logic for `set_brightness`, `set_key_color_direct`, `apply`, and other keyboard trait implementations.

---
*PR created automatically by Jules for task [13609846420198950937](https://jules.google.com/task/13609846420198950937) started by @Ven0m0*