### PR TITLE
🧹 Cleanup Keyboard trait delegation via macro

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "biomejs.biome", 
+    "biomejs.biome",
     "oxc.oxc-vscode",
     "hverlin.mise-vscode",
     "mads-hartmann.bash-ide-vscode",

--- a/src/devices/keyboards/apex.rs
+++ b/src/devices/keyboards/apex.rs
@@ -115,8 +115,7 @@ impl Device for Apex3Tkl {
 }
 
 // Delegate Keyboard trait
-#[async_trait]
-impl Keyboard for Apex3Tkl {
+crate::impl_keyboard_with_delegation!(Apex3Tkl, {
     async fn set_color(&mut self, color: Color) -> Result<()> {
         self.inner.set_color(color).await
     }
@@ -125,108 +124,12 @@ impl Keyboard for Apex3Tkl {
         self.inner.set_zone_colors(colors).await
     }
 
-    fn zone_count(&self) -> usize {
-        self.inner.zone_count()
-    }
-
-    async fn set_brightness(&mut self, brightness: u8) -> Result<()> {
-        self.inner.set_brightness(brightness).await
-    }
-
-    async fn apply(&mut self) -> Result<()> {
-        self.inner.apply().await
-    }
-
-    fn supports_per_key_rgb(&self) -> bool {
-        self.inner.supports_per_key_rgb()
-    }
-
-    fn get_key_mapping(&self) -> Option<&KeyMapping> {
-        self.inner.get_key_mapping()
-    }
-
     async fn set_key_color(&mut self, key_id: KeyId, color: Color) -> Result<()> {
         self.inner.set_key_color(key_id, color).await
     }
 
     async fn set_key_colors(&mut self, key_colors: &[(KeyId, Color)]) -> Result<()> {
         self.inner.set_key_colors(key_colors).await
-    }
-
-    async fn set_key_color_direct(&mut self, address: KeyAddress, color: Color) -> Result<()> {
-        self.inner.set_key_color_direct(address, color).await
-    }
-
-    async fn set_key_colors_direct(&mut self, key_colors: &[(KeyAddress, Color)]) -> Result<()> {
-        self.inner.set_key_colors_direct(key_colors).await
-    }
-
-    async fn clear_per_key_rgb(&mut self) -> Result<()> {
-        self.inner.clear_per_key_rgb().await
-    }
-
-    async fn set_key_region(&mut self, start_hid: u8, count: u8, color: Color) -> Result<()> {
-        self.inner.set_key_region(start_hid, count, color).await
-    }
-
-    fn get_zone_mapping(&self) -> Option<&ZoneMapping> {
-        self.inner.get_zone_mapping()
-    }
-
-    async fn set_zone_effect(&mut self, effect: ZoneEffect) -> Result<()> {
-        self.inner.set_zone_effect(effect).await
-    }
-
-    async fn simulate_per_key_with_zones(&mut self, key_colors: &[(KeyId, Color)]) -> Result<()> {
-        self.inner.simulate_per_key_with_zones(key_colors).await
-    }
-
-    async fn set_zone_colors_with_retry(&mut self, colors: &[Color], max_retries: usize) -> Result<()> {
-        self.inner.set_zone_colors_with_retry(colors, max_retries).await
-    }
-
-    async fn test_zone_reliability(&mut self) -> Result<Vec<bool>> {
-        self.inner.test_zone_reliability().await
-    }
-
-    fn supports_per_key_effects(&self) -> bool {
-        self.inner.supports_per_key_effects()
-    }
-
-    async fn set_per_key_effect(&mut self, effect: PerKeyEffect) -> Result<()> {
-        self.inner.set_per_key_effect(effect).await
-    }
-
-    fn get_per_key_effect(&self) -> Option<&PerKeyEffect> {
-        self.inner.get_per_key_effect()
-    }
-
-    async fn trigger_key_reactive(&mut self, keys: &[KeyId], duration: f32) -> Result<()> {
-        self.inner.trigger_key_reactive(keys, duration).await
-    }
-
-    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
-        self.inner.apply_per_key_effect_with_brightness(brightness).await
-    }
-
-    async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> {
-        self.inner.convert_per_key_to_zones(effect).await
-    }
-
-    fn get_rgb_performance_stats(&self) -> Option<&crate::performance::PerformanceStats> {
-        self.inner.get_rgb_performance_stats()
-    }
-
-    fn get_optimal_frame_time(&self) -> Option<std::time::Duration> {
-        self.inner.get_optimal_frame_time()
-    }
-
-    fn cleanup_rgb_caches(&mut self) {
-        self.inner.cleanup_rgb_caches()
-    }
-
-    fn set_performance_optimization(&mut self, enabled: bool) {
-        self.inner.set_performance_optimization(enabled)
     }
 
     fn read_actuation_point(&mut self) -> Result<u8> {
@@ -240,7 +143,7 @@ impl Keyboard for Apex3Tkl {
     fn set_actuation_point_mm(&mut self, mm: f32) -> Result<()> {
         self.inner.set_actuation_point_mm(mm)
     }
-}
+});
 
 impl std::ops::Deref for Apex3Tkl {
     type Target = GenericKeyboard;

--- a/src/devices/keyboards/apex_pro_tkl_2023.rs
+++ b/src/devices/keyboards/apex_pro_tkl_2023.rs
@@ -318,8 +318,7 @@ impl Device for ApexProTkl2023 {
 }
 
 // Delegate Keyboard trait
-#[async_trait]
-impl Keyboard for ApexProTkl2023 {
+crate::impl_keyboard_with_delegation!(ApexProTkl2023, {
     async fn set_color(&mut self, color: Color) -> Result<()> {
         if self.uses_new_protocol() {
             return self.send_direct_rgb_new_protocol(color);
@@ -334,26 +333,6 @@ impl Keyboard for ApexProTkl2023 {
             return self.send_direct_rgb_new_protocol(color);
         }
         self.inner.set_zone_colors(colors).await
-    }
-
-    fn zone_count(&self) -> usize {
-        self.inner.zone_count()
-    }
-
-    async fn set_brightness(&mut self, brightness: u8) -> Result<()> {
-        self.inner.set_brightness(brightness).await
-    }
-
-    async fn apply(&mut self) -> Result<()> {
-        self.inner.apply().await
-    }
-
-    fn supports_per_key_rgb(&self) -> bool {
-        self.inner.supports_per_key_rgb()
-    }
-
-    fn get_key_mapping(&self) -> Option<&KeyMapping> {
-        self.inner.get_key_mapping()
     }
 
     async fn set_key_color(&mut self, key_id: KeyId, color: Color) -> Result<()> {
@@ -372,84 +351,7 @@ impl Keyboard for ApexProTkl2023 {
         self.inner.set_key_colors(key_colors).await
     }
 
-    async fn set_key_color_direct(&mut self, address: KeyAddress, color: Color) -> Result<()> {
-        self.inner.set_key_color_direct(address, color).await
-    }
-
-    async fn set_key_colors_direct(&mut self, key_colors: &[(KeyAddress, Color)]) -> Result<()> {
-        self.inner.set_key_colors_direct(key_colors).await
-    }
-
-    async fn clear_per_key_rgb(&mut self) -> Result<()> {
-        self.inner.clear_per_key_rgb().await
-    }
-
-    async fn set_key_region(&mut self, start_hid: u8, count: u8, color: Color) -> Result<()> {
-        self.inner.set_key_region(start_hid, count, color).await
-    }
-
-    fn get_zone_mapping(&self) -> Option<&ZoneMapping> {
-        self.inner.get_zone_mapping()
-    }
-
-    async fn set_zone_effect(&mut self, effect: ZoneEffect) -> Result<()> {
-        self.inner.set_zone_effect(effect).await
-    }
-
-    async fn simulate_per_key_with_zones(&mut self, key_colors: &[(KeyId, Color)]) -> Result<()> {
-        self.inner.simulate_per_key_with_zones(key_colors).await
-    }
-
-    async fn set_zone_colors_with_retry(&mut self, colors: &[Color], max_retries: usize) -> Result<()> {
-        self.inner.set_zone_colors_with_retry(colors, max_retries).await
-    }
-
-    async fn test_zone_reliability(&mut self) -> Result<Vec<bool>> {
-        self.inner.test_zone_reliability().await
-    }
-
-    fn supports_per_key_effects(&self) -> bool {
-        self.inner.supports_per_key_effects()
-    }
-
-    async fn set_per_key_effect(&mut self, effect: PerKeyEffect) -> Result<()> {
-        self.inner.set_per_key_effect(effect).await
-    }
-
-    fn get_per_key_effect(&self) -> Option<&PerKeyEffect> {
-        self.inner.get_per_key_effect()
-    }
-
-    async fn trigger_key_reactive(&mut self, keys: &[KeyId], duration: f32) -> Result<()> {
-        self.inner.trigger_key_reactive(keys, duration).await
-    }
-
-    async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> {
-        self.inner.apply_per_key_effect_with_brightness(brightness).await
-    }
-
-    async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> {
-        self.inner.convert_per_key_to_zones(effect).await
-    }
-
-    fn get_rgb_performance_stats(&self) -> Option<&crate::performance::PerformanceStats> {
-        self.inner.get_rgb_performance_stats()
-    }
-
-    fn get_optimal_frame_time(&self) -> Option<std::time::Duration> {
-        self.inner.get_optimal_frame_time()
-    }
-
-    fn cleanup_rgb_caches(&mut self) {
-        self.inner.cleanup_rgb_caches()
-    }
-
-    fn set_performance_optimization(&mut self, enabled: bool) {
-        self.inner.set_performance_optimization(enabled)
-    }
-
     fn read_actuation_point(&mut self) -> Result<u8> {
-        // Implement read if command known, otherwise delegate to inner which returns error
         self.inner.read_actuation_point()
     }
 
@@ -460,7 +362,7 @@ impl Keyboard for ApexProTkl2023 {
     fn set_actuation_point_mm(&mut self, mm: f32) -> Result<()> {
         self.set_actuation_point_mm(mm)
     }
-}
+});
 
 // Deref allows access to Device trait methods like send_raw/receive_raw
 impl Deref for ApexProTkl2023 {

--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -896,6 +896,42 @@ impl Keyboard for GenericKeyboard {
     }
 }
 
+/// Macro to delegate common `Keyboard` trait methods to `self.inner`.
+/// This avoids duplicating dozens of identical trait method implementations.
+#[macro_export]
+macro_rules! impl_keyboard_with_delegation {
+    ($type:ty, { $($custom:item)* }) => {
+        #[async_trait]
+        impl Keyboard for $type {
+            $($custom)*
+            fn zone_count(&self) -> usize { self.inner.zone_count() }
+            async fn set_brightness(&mut self, brightness: u8) -> Result<()> { self.inner.set_brightness(brightness).await }
+            async fn apply(&mut self) -> Result<()> { self.inner.apply().await }
+            fn supports_per_key_rgb(&self) -> bool { self.inner.supports_per_key_rgb() }
+            fn get_key_mapping(&self) -> Option<&KeyMapping> { self.inner.get_key_mapping() }
+            async fn set_key_color_direct(&mut self, address: KeyAddress, color: Color) -> Result<()> { self.inner.set_key_color_direct(address, color).await }
+            async fn set_key_colors_direct(&mut self, key_colors: &[(KeyAddress, Color)]) -> Result<()> { self.inner.set_key_colors_direct(key_colors).await }
+            async fn clear_per_key_rgb(&mut self) -> Result<()> { self.inner.clear_per_key_rgb().await }
+            async fn set_key_region(&mut self, start_hid: u8, count: u8, color: Color) -> Result<()> { self.inner.set_key_region(start_hid, count, color).await }
+            fn get_zone_mapping(&self) -> Option<&ZoneMapping> { self.inner.get_zone_mapping() }
+            async fn set_zone_effect(&mut self, effect: ZoneEffect) -> Result<()> { self.inner.set_zone_effect(effect).await }
+            async fn simulate_per_key_with_zones(&mut self, key_colors: &[(KeyId, Color)]) -> Result<()> { self.inner.simulate_per_key_with_zones(key_colors).await }
+            async fn set_zone_colors_with_retry(&mut self, colors: &[Color], max_retries: usize) -> Result<()> { self.inner.set_zone_colors_with_retry(colors, max_retries).await }
+            async fn test_zone_reliability(&mut self) -> Result<Vec<bool>> { self.inner.test_zone_reliability().await }
+            fn supports_per_key_effects(&self) -> bool { self.inner.supports_per_key_effects() }
+            async fn set_per_key_effect(&mut self, effect: PerKeyEffect) -> Result<()> { self.inner.set_per_key_effect(effect).await }
+            fn get_per_key_effect(&self) -> Option<&PerKeyEffect> { self.inner.get_per_key_effect() }
+            async fn trigger_key_reactive(&mut self, keys: &[KeyId], duration: f32) -> Result<()> { self.inner.trigger_key_reactive(keys, duration).await }
+            async fn apply_per_key_effect_with_brightness(&mut self, brightness: f32) -> Result<()> { self.inner.apply_per_key_effect_with_brightness(brightness).await }
+            async fn convert_per_key_to_zones(&mut self, effect: &PerKeyEffect) -> Result<()> { self.inner.convert_per_key_to_zones(effect).await }
+            fn get_rgb_performance_stats(&self) -> Option<&$crate::performance::PerformanceStats> { self.inner.get_rgb_performance_stats() }
+            fn get_optimal_frame_time(&self) -> Option<std::time::Duration> { self.inner.get_optimal_frame_time() }
+            fn cleanup_rgb_caches(&mut self) { self.inner.cleanup_rgb_caches() }
+            fn set_performance_optimization(&mut self, enabled: bool) { self.inner.set_performance_optimization(enabled) }
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
🎯 **What:** Deduplicated boilerplate `Keyboard` trait implementations for `ApexProTkl2023` and `Apex3Tkl` by creating an `impl_keyboard_with_delegation` macro in `src/devices/keyboards/mod.rs`. This removed over 40 duplicate function bodies like `set_key_colors_direct`.

💡 **Why:** By extracting trait implementations that purely delegate to `self.inner` into a macro, the code becomes substantially more maintainable and cleaner. Custom overrides (like `set_color` and `set_actuation_point`) remain explicit and easier to spot, while avoiding the overhead of duplicating 25+ trivial trait method definitions per keyboard model.

✅ **Verification:** 
- `cargo check` and `cargo test` run cleanly. 
- All custom overriding methods are kept intact.
- Clippy issues regarding `$crate` and doc comments in macro were resolved.

✨ **Result:** A significant reduction of repetitive boilerplate code. Future keyboard implementations wrapping `GenericKeyboard` will now be vastly simpler.

---
*PR created automatically by Jules for task [17841126854294014376](https://jules.google.com/task/17841126854294014376) started by @Ven0m0*