### PR TITLE
⚡ Optimize gamesense_overlays memory management

### DIFF
--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -65,9 +65,7 @@ pub trait Keyboard: Device {
     /// Uses the keyboard's key mapping to convert logical key IDs to matrix addresses.
     /// Returns an error if the key is not found in the mapping or per-key RGB is not supported.
     async fn set_key_color(&mut self, _key_id: KeyId, _color: Color) -> Result<()> {
-        Err(Error::DeviceCommunication(
-            "Per-key RGB not supported".to_string(),
-        ))
+        Err(Error::DeviceCommunication("Per-key RGB not supported".to_string()))
     }
 
     /// Set RGB colors for multiple keys by logical key IDs.

--- a/src/devices/zone_mapping.rs
+++ b/src/devices/zone_mapping.rs
@@ -703,13 +703,14 @@ mod tests {
         let colors = res.unwrap();
         // Both A and Q should map to the same MainKeys zone selected by the current mapping logic.
         // Verify that one zone contains a blended color produced from both inputs.
-        let a_zone_idx = map_key_to_zone(product_ids::APEX_PRO_TKL_2023, crate::devices::KeyId::A);
-        let q_zone_idx = map_key_to_zone(product_ids::APEX_PRO_TKL_2023, crate::devices::KeyId::Q);
+        let mapping = fallback.get_mapping(product_ids::APEX_PRO_TKL_2023).unwrap();
+        let a_zone_idx = fallback.map_key_to_zone(crate::devices::KeyId::A, mapping);
+        let q_zone_idx = fallback.map_key_to_zone(crate::devices::KeyId::Q, mapping);
         assert_eq!(
             a_zone_idx, q_zone_idx,
             "A and Q should map to the same zone for blending on Apex Pro TKL 2023"
         );
-        let zone_idx = a_zone_idx;
+        let zone_idx = a_zone_idx.unwrap();
         assert_eq!(
             colors[zone_idx],
             Color::blend(Color::RED, Color::BLUE, 0.5),

--- a/src/devices/zone_mapping.rs
+++ b/src/devices/zone_mapping.rs
@@ -710,7 +710,12 @@ mod tests {
             a_zone_idx, q_zone_idx,
             "A and Q should map to the same zone for blending on Apex Pro TKL 2023"
         );
-        let zone_idx = a_zone_idx.unwrap();
+        assert!(
+            a_zone_idx.is_some(),
+            "A and Q should both map to a valid zone on Apex Pro TKL 2023"
+        );
+        let zone_idx =
+            a_zone_idx.expect("A and Q should both map to a valid zone on Apex Pro TKL 2023");
         assert_eq!(
             colors[zone_idx],
             Color::blend(Color::RED, Color::BLUE, 0.5),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1384,7 +1384,7 @@ async fn cmd_profile(action: ProfileAction) -> Result<()> {
         }
 
         ProfileAction::Delete { name } => {
-            profile_manager.delete(&name)?;
+profile_manager.delete_async(&name).await?;
             println!("Profile deleted: {}", name);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1384,7 +1384,7 @@ async fn cmd_profile(action: ProfileAction) -> Result<()> {
         }
 
         ProfileAction::Delete { name } => {
-            profile_manager.delete(&name).await?;
+            profile_manager.delete(&name)?;
             println!("Profile deleted: {}", name);
         }
     }
@@ -2110,7 +2110,7 @@ async fn cmd_server(port: u16) -> Result<()> {
 struct DaemonState {
     keyboards: HashMap<String, (Box<dyn Keyboard>, RgbController, DeviceInfo)>,
     headsets: HashMap<String, (Box<dyn Headset>, DeviceInfo)>,
-    gamesense_overlays: HashMap<String, (Color, std::time::Instant)>, // zone -> (color, expiry)
+    gamesense_overlays: Arc<HashMap<String, (Color, std::time::Instant)>>, // zone -> (color, expiry)
     /// Device fingerprints for tracking devices across reconnections
     device_fingerprints: HashMap<String, DeviceFingerprint>,
     /// Profile manager for applying settings to reconnected devices
@@ -2127,7 +2127,7 @@ impl DaemonState {
         Ok(Self {
             keyboards: HashMap::new(),
             headsets: HashMap::new(),
-            gamesense_overlays: HashMap::new(),
+            gamesense_overlays: Arc::new(HashMap::new()),
             device_fingerprints: HashMap::new(),
             profile_manager,
             state_store,
@@ -2926,8 +2926,7 @@ fn start_gamesense_server(config: &Config, daemon_state: Arc<RwLock<DaemonState>
 
                             // Use try_write to avoid blocking if the lock is busy
                             if let Ok(mut state_guard) = state.try_write() {
-                                state_guard
-                                    .gamesense_overlays
+                                Arc::make_mut(&mut state_guard.gamesense_overlays)
                                     .insert(zone_owned.clone(), (color, expiry));
                                 tracing::debug!("GameSense overlay: {} = {:?}", zone_owned, color);
                             } else {
@@ -2936,7 +2935,8 @@ fn start_gamesense_server(config: &Config, daemon_state: Arc<RwLock<DaemonState>
                                 let zone_deferred = zone_owned.clone();
                                 tokio::spawn(async move {
                                     let mut state = state_clone.write().await;
-                                    state.gamesense_overlays.insert(zone_deferred.clone(), (color, expiry));
+                                    Arc::make_mut(&mut state.gamesense_overlays)
+                                        .insert(zone_deferred.clone(), (color, expiry));
                                     tracing::debug!("GameSense overlay (deferred): {} = {:?}", zone_deferred, color);
                                 });
                             }
@@ -3070,7 +3070,10 @@ async fn run_animation_loop(daemon_state_anim: Arc<RwLock<DaemonState>>) {
 
             // Clean up expired overlays while we have the lock
             let now = std::time::Instant::now();
-            state.gamesense_overlays.retain(|_, (_, expiry)| *expiry > now);
+            let has_expired = state.gamesense_overlays.iter().any(|(_, (_, expiry))| *expiry <= now);
+            if has_expired {
+                Arc::make_mut(&mut state.gamesense_overlays).retain(|_, (_, expiry)| *expiry > now);
+            }
 
             // Collect data needed for RGB computation to minimize lock time
             // Reuse frame_data_buffer to avoid allocations
@@ -3101,12 +3104,8 @@ async fn run_animation_loop(daemon_state_anim: Arc<RwLock<DaemonState>>) {
                 count += 1;
             }
 
-            // Clone overlays only if there are any
-            let overlays = if state.gamesense_overlays.is_empty() {
-                Arc::new(HashMap::new())
-            } else {
-                Arc::new(state.gamesense_overlays.clone()) // Clone once, cheap Arc clones after
-            };
+            // Fast atomic clone of the Arc
+            let overlays = Arc::clone(&state.gamesense_overlays);
 
             (count, overlays, now)
         };

--- a/src/profiles/tests.rs
+++ b/src/profiles/tests.rs
@@ -157,7 +157,7 @@ async fn benchmark_profile_deletion() {
 
     let start = Instant::now();
     for i in 0..num_profiles {
-        manager.delete(&format!("Profile_{}", i)).unwrap();
+manager.delete_async(&format!("Profile_{}", i)).await.unwrap();
     }
     let duration = start.elapsed();
 

--- a/src/profiles/tests.rs
+++ b/src/profiles/tests.rs
@@ -157,7 +157,7 @@ async fn benchmark_profile_deletion() {
 
     let start = Instant::now();
     for i in 0..num_profiles {
-        manager.delete(&format!("Profile_{}", i)).await.unwrap();
+        manager.delete(&format!("Profile_{}", i)).unwrap();
     }
     let duration = start.elapsed();
 


### PR DESCRIPTION
💡 **What:**
Changed `gamesense_overlays` in `DaemonState` from `HashMap` to `Arc<HashMap>`.
Updated mutations to use `Arc::make_mut` (copy-on-write).
Updated `run_animation_loop` to use `Arc::clone` instead of `.clone()`.
Updated overlay expiry cleanup to only mutate if expired items exist.

🎯 **Why:**
Previously, the `run_animation_loop` cloned the entire `gamesense_overlays` HashMap every frame (up to 60Hz) if it was not empty. This incurred O(N) allocation and copying overhead.
By wrapping the map in an `Arc`, this changes to an O(1) atomic reference count increment, drastically reducing CPU usage and memory churn in the hot path.

📊 **Measured Improvement:**
While the local `performance benchmark` could not be run as it requires physical SteelSeries hardware, this change mathematically improves the hot path by reducing O(N) heap allocations (where N is the number of active overlays) to a single O(1) atomic operation per frame.

---
*PR created automatically by Jules for task [6422643961475019545](https://jules.google.com/task/6422643961475019545) started by @Ven0m0*