### PR TITLE
⚡ Optimize sysfs file I/O to use non-blocking tokio async

### DIFF
--- a/src/devices/zone_mapping.rs
+++ b/src/devices/zone_mapping.rs
@@ -714,8 +714,7 @@ mod tests {
             a_zone_idx.is_some(),
             "A and Q should both map to a valid zone on Apex Pro TKL 2023"
         );
-        let zone_idx =
-            a_zone_idx.expect("A and Q should both map to a valid zone on Apex Pro TKL 2023");
+        let zone_idx = a_zone_idx.expect("A and Q should both map to a valid zone on Apex Pro TKL 2023");
         assert_eq!(
             colors[zone_idx],
             Color::blend(Color::RED, Color::BLUE, 0.5),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1384,7 +1384,7 @@ async fn cmd_profile(action: ProfileAction) -> Result<()> {
         }
 
         ProfileAction::Delete { name } => {
-profile_manager.delete_async(&name).await?;
+            profile_manager.delete_async(&name).await?;
             println!("Profile deleted: {}", name);
         }
     }
@@ -1406,7 +1406,7 @@ async fn cmd_pollrate(action: PollrateAction) -> Result<()> {
                 println!();
             }
 
-            set_poll_rate(DeviceType::Mouse, poll_rate)?;
+            set_poll_rate(DeviceType::Mouse, poll_rate).await?;
             println!("Mouse polling rate set to {} Hz", rate);
 
             if persistent {
@@ -1427,7 +1427,7 @@ async fn cmd_pollrate(action: PollrateAction) -> Result<()> {
                 println!();
             }
 
-            set_poll_rate(DeviceType::Keyboard, poll_rate)?;
+            set_poll_rate(DeviceType::Keyboard, poll_rate).await?;
             println!("Keyboard polling rate set to {} Hz", rate);
 
             if persistent {
@@ -1442,12 +1442,12 @@ async fn cmd_pollrate(action: PollrateAction) -> Result<()> {
             println!("Current USB Polling Rates:");
             println!();
 
-            match get_poll_rate(DeviceType::Mouse) {
+            match get_poll_rate(DeviceType::Mouse).await {
                 Ok(rate) => println!("  Mouse:    {} Hz", rate.to_hz()),
                 Err(e) => println!("  Mouse:    Error: {}", e),
             }
 
-            match get_poll_rate(DeviceType::Keyboard) {
+            match get_poll_rate(DeviceType::Keyboard).await {
                 Ok(rate) => println!("  Keyboard: {} Hz", rate.to_hz()),
                 Err(e) => println!("  Keyboard: Error: {}", e),
             }
@@ -2289,7 +2289,7 @@ async fn cmd_daemon(mut manager: DeviceManager) -> Result<()> {
     let config = Config::load_async().await?;
 
     // Apply saved polling rates
-    apply_saved_poll_rates(&config);
+    apply_saved_poll_rates(&config).await;
 
     // Initialize daemon state
     let daemon_state = Arc::new(RwLock::new(DaemonState::new().await?));
@@ -2800,12 +2800,12 @@ async fn cmd_verify_performance(
     Ok(())
 }
 
-fn apply_saved_poll_rates(config: &Config) {
+async fn apply_saved_poll_rates(config: &Config) {
     use steelseries_gg::pollrate::{DeviceType, PollRate, set_poll_rate};
 
     if let Some(mouse_hz) = config.poll_rate.mouse_hz {
         match PollRate::from_hz(mouse_hz) {
-            Ok(rate) => match set_poll_rate(DeviceType::Mouse, rate) {
+            Ok(rate) => match set_poll_rate(DeviceType::Mouse, rate).await {
                 Ok(()) => info!("Applied mouse poll rate: {} Hz", mouse_hz),
                 Err(e) => tracing::warn!("Failed to set mouse poll rate: {}", e),
             },
@@ -2821,7 +2821,7 @@ fn apply_saved_poll_rates(config: &Config) {
 
     if let Some(keyboard_hz) = config.poll_rate.keyboard_hz {
         match PollRate::from_hz(keyboard_hz) {
-            Ok(rate) => match set_poll_rate(DeviceType::Keyboard, rate) {
+            Ok(rate) => match set_poll_rate(DeviceType::Keyboard, rate).await {
                 Ok(()) => info!("Applied keyboard poll rate: {} Hz", keyboard_hz),
                 Err(e) => tracing::warn!("Failed to set keyboard poll rate: {}", e),
             },

--- a/src/pollrate.rs
+++ b/src/pollrate.rs
@@ -146,10 +146,12 @@ fn is_root() -> bool {
 /// use steelseries_gg::pollrate::{set_poll_rate, DeviceType, PollRate};
 ///
 /// // Requires root privileges
-/// set_poll_rate(DeviceType::Mouse, PollRate::Hz1000)?;
+/// tokio::runtime::Runtime::new().unwrap().block_on(async {
+///     set_poll_rate(DeviceType::Mouse, PollRate::Hz1000).await
+/// })?;
 /// # Ok::<(), steelseries_gg::Error>(())
 /// ```
-pub fn set_poll_rate(device_type: DeviceType, rate: PollRate) -> Result<()> {
+pub async fn set_poll_rate(device_type: DeviceType, rate: PollRate) -> Result<()> {
     if !is_root() {
         let bin_name = match std::env::current_exe() {
             Ok(path) => path
@@ -170,7 +172,7 @@ pub fn set_poll_rate(device_type: DeviceType, rate: PollRate) -> Result<()> {
     let path = device_type.sysfs_path();
     let value = rate.to_sysfs_value().to_string();
 
-    std::fs::write(path, &value).map_err(|e| {
+    tokio::fs::write(path, &value).await.map_err(|e| {
         Error::Io(std::io::Error::new(
             e.kind(),
             format!(
@@ -197,14 +199,16 @@ pub fn set_poll_rate(device_type: DeviceType, rate: PollRate) -> Result<()> {
 /// ```no_run
 /// use steelseries_gg::pollrate::{get_poll_rate, DeviceType};
 ///
-/// let rate = get_poll_rate(DeviceType::Mouse)?;
+/// let rate = tokio::runtime::Runtime::new().unwrap().block_on(async {
+///     get_poll_rate(DeviceType::Mouse).await
+/// })?;
 /// println!("Current mouse poll rate: {} Hz", rate.to_hz());
 /// # Ok::<(), steelseries_gg::Error>(())
 /// ```
-pub fn get_poll_rate(device_type: DeviceType) -> Result<PollRate> {
+pub async fn get_poll_rate(device_type: DeviceType) -> Result<PollRate> {
     let path = device_type.sysfs_path();
 
-    let content = std::fs::read_to_string(path).map_err(|e| {
+    let content = tokio::fs::read_to_string(path).await.map_err(|e| {
         Error::Io(std::io::Error::new(
             e.kind(),
             format!(

--- a/src/profiles/tests.rs
+++ b/src/profiles/tests.rs
@@ -157,7 +157,7 @@ async fn benchmark_profile_deletion() {
 
     let start = Instant::now();
     for i in 0..num_profiles {
-manager.delete_async(&format!("Profile_{}", i)).await.unwrap();
+        manager.delete_async(&format!("Profile_{}", i)).await.unwrap();
     }
     let duration = start.elapsed();
 


### PR DESCRIPTION
💡 **What:**
Updated `get_poll_rate` and `set_poll_rate` in `src/pollrate.rs` to be `async fn` and to use `tokio::fs::read_to_string` / `tokio::fs::write` instead of synchronous `std::fs` operations. Propagated `.await` to the calling contexts in `src/main.rs`.

🎯 **Why:**
The application uses `tokio` as its async runtime. Calling synchronous blocking I/O functions like `std::fs::read_to_string` and `std::fs::write` directly on an async executor thread can cause that thread to block, potentially starving other concurrent async tasks in the application. Using the asynchronous file operations allows the runtime to schedule other tasks while waiting for sysfs operations to complete.

📊 **Measured Improvement:**
Since this code interacts with sysfs paths (`/sys/module/usbhid/parameters/...`) that only exist natively in a full Linux root environment with the `usbhid` driver loaded, benchmarking it reliably in an unprivileged test container environment simply measures the error return path time rather than actual I/O. Therefore, a meaningful numerical measurement of the sysfs read/write time wasn't strictly possible. However, moving blocking operations off the async executor thread is a universally recognized best practice in async Rust to prevent executor starvation and improve overall application throughput.

---
*PR created automatically by Jules for task [1877585229270562495](https://jules.google.com/task/1877585229270562495) started by @Ven0m0*