### PR TITLE
⚡ Remove unnecessary String clone in ProfileAction::Save

### DIFF
--- a/src/devices/zone_mapping.rs
+++ b/src/devices/zone_mapping.rs
@@ -714,8 +714,7 @@ mod tests {
             a_zone_idx.is_some(),
             "A and Q should both map to a valid zone on Apex Pro TKL 2023"
         );
-        let zone_idx =
-            a_zone_idx.expect("A and Q should both map to a valid zone on Apex Pro TKL 2023");
+        let zone_idx = a_zone_idx.expect("A and Q should both map to a valid zone on Apex Pro TKL 2023");
         assert_eq!(
             colors[zone_idx],
             Color::blend(Color::RED, Color::BLUE, 0.5),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1361,7 +1361,7 @@ async fn cmd_profile(action: ProfileAction) -> Result<()> {
         }
 
         ProfileAction::Save { name } => {
-            let mut profile = Profile::new(name.clone());
+            let mut profile = Profile::new(name);
             let state_store = DeviceStateStore::new()?;
             let device_manager = DeviceManager::new()?;
 
@@ -1379,12 +1379,12 @@ async fn cmd_profile(action: ProfileAction) -> Result<()> {
                 }
             }
 
-            profile_manager.set(profile)?;
-            println!("Profile saved: {}", name);
+            let saved_profile = profile_manager.set(profile)?;
+            println!("Profile saved: {}", saved_profile.name);
         }
 
         ProfileAction::Delete { name } => {
-profile_manager.delete_async(&name).await?;
+            profile_manager.delete_async(&name).await?;
             println!("Profile deleted: {}", name);
         }
     }

--- a/src/profiles/mod.rs
+++ b/src/profiles/mod.rs
@@ -230,10 +230,18 @@ impl ProfileManager {
     }
 
     /// Add or update a profile.
-    pub fn set(&mut self, profile: Profile) -> Result<()> {
+    pub fn set(&mut self, profile: Profile) -> Result<&Profile> {
         self.save(&profile)?;
-        self.profiles.insert(profile.name.clone(), profile);
-        Ok(())
+        let name = profile.name.clone();
+        use std::collections::hash_map::Entry;
+        let profile_ref = match self.profiles.entry(name) {
+            Entry::Occupied(mut e) => {
+                e.insert(profile);
+                e.into_mut()
+            }
+            Entry::Vacant(e) => e.insert(profile),
+        };
+        Ok(profile_ref)
     }
 
     /// Delete a profile.

--- a/src/profiles/tests.rs
+++ b/src/profiles/tests.rs
@@ -157,7 +157,7 @@ async fn benchmark_profile_deletion() {
 
     let start = Instant::now();
     for i in 0..num_profiles {
-manager.delete_async(&format!("Profile_{}", i)).await.unwrap();
+        manager.delete_async(&format!("Profile_{}", i)).await.unwrap();
     }
     let duration = start.elapsed();
 


### PR DESCRIPTION
💡 **What:** 
Removed an unnecessary `name.clone()` when creating a `Profile` inside `ProfileAction::Save` handling in `src/main.rs`. To allow the `println!` statement to successfully output the profile name after it is moved and consumed by `profile_manager.set()`, `ProfileManager::set` (in `src/profiles/mod.rs`) was optimized to return `Result<&Profile>` instead of `Result<()>`. This utilizes the `HashMap::entry` API internally to avoid double-cloning the name key while yielding a safe reference back to the caller.

🎯 **Why:** 
The previous implementation performed a redundant heap allocation (`name.clone()`) on a `String` because the `ProfileAction::Save { name }` enum variant already provides an owned `String`. By modifying `ProfileManager::set` to return a reference to the successfully inserted profile, we can consume the originally owned string and gracefully borrow the name from the cache for logging output.

📊 **Measured Improvement:** 
This refactor completely eliminates the extra string allocation occurring in the main CLI entrypoint during profile saving, yielding a zero-allocation solution for the log output without compromising memory safety or functional correctness.

---
*PR created automatically by Jules for task [14286454443036939231](https://jules.google.com/task/14286454443036939231) started by @Ven0m0*