### PR TITLE
🧹 Replace placeholder 'XXXX' in DeviceId parsing test

### DIFF
--- a/src/device_state.rs
+++ b/src/device_state.rs
@@ -757,7 +757,7 @@ mod tests {
         assert!(DeviceId::from_key("103G:1234:1:serial:none").is_err());
 
         // Invalid hex product_id
-        assert!(DeviceId::from_key("1038:XXXX:1:serial:none").is_err());
+        assert!(DeviceId::from_key("1038:G123:1:serial:none").is_err());
 
         // Invalid interface integer
         assert!(DeviceId::from_key("1038:1234:A:serial:none").is_err());


### PR DESCRIPTION
🎯 **What:** Replaced the generic placeholder `'XXXX'` with a specific invalid hexadecimal value `'G123'` in the `DeviceId::from_key` unit test within `src/device_state.rs`.

💡 **Why:** Improving test data readability and consistency makes the test suite easier to maintain. Using a value like `'G123'` clearly demonstrates that the test is checking for hexadecimal parsing failures, matching the pattern used in adjacent test cases.

✅ **Verification:** Verified by running `cargo test device_state::tests::test_device_id_from_key_invalid`, which confirms the parser still correctly identifies this as invalid input and returns an error.

✨ **Result:** Enhanced code health and readability in the device state persistence test suite.

---
*PR created automatically by Jules for task [14554118763029406274](https://jules.google.com/task/14554118763029406274) started by @Ven0m0*