### PR TITLE
🔒 Fix insecure file write in benchmark and performance reports

### DIFF
--- a/src/device_state.rs
+++ b/src/device_state.rs
@@ -282,12 +282,11 @@ impl DeviceStateStore {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::OpenOptionsExt;
+
                 let mut options = std::fs::OpenOptions::new();
                 options.write(true).create(true).truncate(true).mode(0o600);
 
-                let mut file = options
-                    .open(&temp_file_clone)
-                    .map_err(|e| Error::FileSystemError(format!("Failed to open temp file: {}", e)))?;
+                let mut file = crate::fs_utils::secure_open(&temp_file_clone, &options)?;
 
                 let mut perms = file
                     .metadata()
@@ -662,7 +661,7 @@ mod tests {
             legacy_id_str
         );
 
-        std::fs::write(&state_file, initial_json)?;
+        crate::fs_utils::secure_write(&state_file, initial_json)?;
 
         let store = DeviceStateStore::with_path(state_file.clone())?;
 

--- a/src/diagnostics_export.rs
+++ b/src/diagnostics_export.rs
@@ -16,6 +16,7 @@ use tracing::{debug, warn};
 
 use crate::device_state::{DeviceId, DeviceState, DeviceStateStore};
 use crate::devices::{DeviceInfo, DeviceManager};
+use crate::fs_utils::secure_write_async;
 use crate::performance::RgbTimingMetrics;
 use crate::{Error, Result};
 use std::path::PathBuf;
@@ -347,8 +348,8 @@ pub async fn export_bug_report(report: &BugReport, path: &str) -> Result<()> {
     let json_content = serde_json::to_string_pretty(report)
         .map_err(|e| Error::SerializationMessage(format!("Failed to serialize report: {}", e)))?;
 
-    // Write to file using async I/O
-    tokio::fs::write(path, &json_content)
+    // Write to file using secure async I/O
+    secure_write_async(path.to_string(), json_content.clone())
         .await
         .map_err(|e| Error::FileSystemError(format!("Failed to write report: {}", e)))?;
 

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -1,0 +1,78 @@
+//! Secure file utilities for SteelSeries GG.
+
+use crate::{Error, Result};
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+
+/// Open a file securely, preventing symlink attacks on Unix.
+pub fn secure_open<P: AsRef<Path>>(path: P, options: &OpenOptions) -> Result<File> {
+    let path = path.as_ref();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // Refuse to operate on an existing symlink.
+        if let Ok(metadata) = std::fs::symlink_metadata(path) {
+            if metadata.file_type().is_symlink() {
+                return Err(Error::FileSystemError(format!(
+                    "Refusing to operate on {} because it is a symlink",
+                    path.display()
+                )));
+            }
+        }
+
+        let mut secure_options = options.clone();
+        secure_options.custom_flags(libc::O_NOFOLLOW);
+
+        let file = match secure_options.open(path) {
+            Ok(file) => file,
+            Err(err) => {
+                if err.raw_os_error() == Some(libc::ELOOP) {
+                    return Err(Error::FileSystemError(format!(
+                        "Refusing to operate on {} because it is (or contains) a symlink",
+                        path.display()
+                    )));
+                }
+                return Err(err.into());
+            }
+        };
+        Ok(file)
+    }
+
+    #[cfg(not(unix))]
+    {
+        options.open(path).map_err(|e| e.into())
+    }
+}
+
+/// Write data to a file securely, preventing symlink attacks on Unix.
+pub fn secure_write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
+    let path = path.as_ref();
+    let contents = contents.as_ref();
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = secure_open(path, &options)?;
+
+    use std::io::Write;
+    file.write_all(contents)?;
+
+    Ok(())
+}
+
+/// Asynchronously write data to a file securely.
+pub async fn secure_write_async<P: AsRef<Path> + Send + 'static, C: AsRef<[u8]> + Send + 'static>(
+    path: P,
+    contents: C,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || secure_write(path, contents))
+        .await
+        .map_err(|e| Error::Other(format!("Task join error: {}", e)))?
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod config;
 pub mod device_state;
 pub mod devices;
+pub mod fs_utils;
 pub mod diagnostics_export;
 pub mod error;
 pub mod gamesense;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use tracing::{Level, debug, info, warn};
 use tracing_subscriber::FmtSubscriber;
 
 use steelseries_gg::config::Config;
+use steelseries_gg::fs_utils::{secure_write, secure_write_async};
 use steelseries_gg::device_state::{DeviceId, DeviceStateStore, KeyboardState};
 use steelseries_gg::devices::headsets::Headset;
 use steelseries_gg::devices::keyboards::Keyboard;
@@ -1785,7 +1786,7 @@ async fn cmd_validate(
             content
         };
 
-        tokio::fs::write(&output_path, export_content)
+        secure_write_async(output_path.clone(), export_content)
             .await
             .map_err(|e| Error::FileSystemError(format!("Failed to write report: {}", e)))?;
 
@@ -1966,7 +1967,7 @@ async fn cmd_performance(manager: &DeviceManager, action: PerformanceAction) -> 
                     "results": benchmark_results
                 });
 
-                std::fs::write(&output_path, serde_json::to_string_pretty(&benchmark_data)?)
+                secure_write(&output_path, serde_json::to_string_pretty(&benchmark_data)?)
                     .map_err(|e| Error::DeviceCommunication(format!("Failed to write benchmark: {}", e)))?;
 
                 println!("📄 Benchmark results exported to: {}", output_path);
@@ -2054,7 +2055,7 @@ fn export_performance_stats(
             "devices": all_stats
         });
 
-        std::fs::write(output_path, serde_json::to_string_pretty(&export_data)?)
+        secure_write(output_path, serde_json::to_string_pretty(&export_data)?)
             .map_err(|e| Error::DeviceCommunication(format!("Failed to write stats: {}", e)))?;
     } else {
         let mut content = String::new();
@@ -2090,7 +2091,7 @@ fn export_performance_stats(
             }
         }
 
-        std::fs::write(output_path, content)
+        secure_write(output_path, content)
             .map_err(|e| Error::DeviceCommunication(format!("Failed to write stats: {}", e)))?;
     }
 
@@ -2819,10 +2820,9 @@ async fn cmd_verify_performance(
 
     // Export to JSON if requested
     if let Some(output_path) = output {
-        use std::fs;
         let json = serde_json::to_string_pretty(&metrics)
             .map_err(|e| Error::Other(format!("Failed to serialize metrics: {}", e)))?;
-        fs::write(&output_path, json).map_err(|e| Error::Other(format!("Failed to write {}: {}", output_path, e)))?;
+        secure_write(&output_path, json).map_err(|e| Error::Other(format!("Failed to write {}: {}", output_path, e)))?;
         println!("\nMetrics exported to: {}", output_path);
     }
 

--- a/src/profiles/mod.rs
+++ b/src/profiles/mod.rs
@@ -213,7 +213,9 @@ impl ProfileManager {
         {
             let mut options = OpenOptions::new();
             options.write(true).create(true).truncate(true).mode(0o600);
-            let file = options.open(&path)?;
+
+            let file = crate::fs_utils::secure_open(&path, &options)
+                .map_err(|e| Error::Profile(e.to_string()))?;
             let mut perms = file.metadata()?.permissions();
             perms.set_mode(0o600);
             file.set_permissions(perms)?;

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use tempfile::tempdir;
+use steelseries_gg::fs_utils::{secure_write, secure_write_async};
+
+#[cfg(unix)]
+#[test]
+fn test_secure_write_refuses_symlink() {
+    use std::os::unix::fs::symlink;
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+
+    // Create a target file
+    fs::write(&target, "target content").unwrap();
+
+    // Create a symlink pointing to the target
+    symlink(&target, &link).unwrap();
+
+    // Attempt to write to the link using secure_write
+    let result = secure_write(&link, "malicious content");
+
+    // It should fail
+    assert!(result.is_err());
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(err_msg.contains("symlink"));
+
+    // Verify target content was NOT changed
+    let content = fs::read_to_string(&target).unwrap();
+    assert_eq!(content, "target content");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_secure_write_async_refuses_symlink() {
+    use std::os::unix::fs::symlink;
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("target_async.txt");
+    let link = dir.path().join("link_async.txt");
+
+    // Create a target file
+    fs::write(&target, "target content").unwrap();
+
+    // Create a symlink pointing to the target
+    symlink(&target, &link).unwrap();
+
+    // Attempt to write to the link using secure_write_async
+    let result = secure_write_async(link.to_string_lossy().to_string(), "malicious content".to_string()).await;
+
+    // It should fail
+    assert!(result.is_err());
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(err_msg.contains("symlink"));
+
+    // Verify target content was NOT changed
+    let content = fs::read_to_string(&target).unwrap();
+    assert_eq!(content, "target content");
+}
+
+#[test]
+fn test_secure_write_creates_new_file() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("new_file.txt");
+
+    let result = secure_write(&path, "new content");
+    assert!(result.is_ok());
+
+    let content = fs::read_to_string(&path).unwrap();
+    assert_eq!(content, "new content");
+
+    // Check permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = fs::metadata(&path).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Fixed insecure file writes that followed symlinks by introducing a centralized `fs_utils` module with symlink protection.

⚠️ **Risk:** Potential for symlink attacks where an attacker could overwrite sensitive system files (e.g., `/etc/shadow`) by pointing an export path to a symlink.

🛡️ **Solution:** Implemented `secure_open`, `secure_write`, and `secure_write_async` using `O_NOFOLLOW` and `symlink_metadata` checks on Unix systems. Updated multiple call sites in `main.rs`, `diagnostics_export.rs`, `device_state.rs`, and `profiles/mod.rs` to use these secure utilities. Added automated security tests to prevent regressions.

---
*PR created automatically by Jules for task [1645721205253382368](https://jules.google.com/task/1645721205253382368) started by @Ven0m0*