### PR TITLE
🧪 Add error path tests for GameSenseServer address parsing

### DIFF
--- a/src/gamesense/server.rs
+++ b/src/gamesense/server.rs
@@ -392,6 +392,34 @@ mod tests {
     }
 
     #[test]
+    fn test_server_new() {
+        // Valid address
+        let server = GameSenseServer::new("127.0.0.1", 0);
+        assert!(server.is_ok());
+        assert_eq!(server.unwrap().address().ip().to_string(), "127.0.0.1");
+
+        // Valid IPv6 address
+        let server_v6 = GameSenseServer::new("[::1]", 0);
+        assert!(server_v6.is_ok());
+        assert_eq!(server_v6.unwrap().address().ip().to_string(), "::1");
+    }
+
+    #[test]
+    fn test_server_new_invalid_address() {
+        // Invalid host
+        let result = GameSenseServer::new("invalid_host", 8080);
+        assert!(matches!(result, Err(Error::GameSense(ref m)) if m.contains("Invalid bind address")));
+
+        // Empty host
+        let result = GameSenseServer::new("", 8080);
+        assert!(matches!(result, Err(Error::GameSense(ref m)) if m.contains("Invalid bind address")));
+
+        // Invalid IP format
+        let result = GameSenseServer::new("127.0.0.1.1", 8080);
+        assert!(matches!(result, Err(Error::GameSense(ref m)) if m.contains("Invalid bind address")));
+    }
+
+    #[test]
     fn test_compute_color_gradient() {
         let handler = ColorHandler::Gradient {
             gradient: GradientSpec {


### PR DESCRIPTION
🎯 **What:** Missing error path test for GameSenseServer address parsing.

📊 **Coverage:**
- Added `test_server_new`: Verifies successful server creation with valid IPv4 (`127.0.0.1`) and IPv6 (`[::1]`) addresses.
- Added `test_server_new_invalid_address`: Verifies that invalid inputs (invalid hostname, empty hostname, and malformed IP) correctly return `Error::GameSense`.

✨ **Result:** Improved test coverage for the GameSense server initialization logic and ensured that address parsing errors are correctly propagated.

---
*PR created automatically by Jules for task [3583824254947577986](https://jules.google.com/task/3583824254947577986) started by @Ven0m0*