### PR TITLE
🧹 Remove duplicate code in benchmark_fragment.rs

### DIFF
--- a/src/bin/benchmark_fragment.rs
+++ b/src/bin/benchmark_fragment.rs
@@ -1,116 +1,50 @@
-use std::collections::HashMap;
 use std::time::Instant;
+use steelseries_gg::devices::hid_reports::{PerKeyAddressingMode, PerKeyRgbCommand};
+use steelseries_gg::devices::key_mapping::KeyAddress;
+use steelseries_gg::rgb::Color;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KeyAddress {
-    pub row: u8,
-    pub col: u8,
-}
+pub fn fragment_into_reports_original(cmd: &PerKeyRgbCommand) -> Vec<PerKeyRgbCommand> {
+    let mut fragments = Vec::new();
+    let chunk_size = PerKeyRgbCommand::MAX_KEYS_PER_REPORT;
+    let keys: Vec<_> = cmd.key_colors.iter().collect();
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Color {
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PerKeyAddressingMode {
-    Matrix,
-    Logical,
-}
-
-#[derive(Debug, Clone)]
-pub struct PerKeyRgbCommand {
-    pub key_colors: HashMap<KeyAddress, Color>,
-    pub addressing_mode: PerKeyAddressingMode,
-}
-
-impl PerKeyRgbCommand {
-    pub const MAX_KEYS_PER_REPORT: usize = 12;
-
-    pub fn fragment_into_reports_original(&self) -> Vec<PerKeyRgbCommand> {
-        let mut fragments = Vec::new();
-        let chunk_size = Self::MAX_KEYS_PER_REPORT;
-        let keys: Vec<_> = self.key_colors.iter().collect();
-
-        if keys.is_empty() {
-            return vec![self.clone()];
-        }
-
-        for chunk in keys.chunks(chunk_size) {
-            let mut fragment_command = PerKeyRgbCommand {
-                key_colors: HashMap::new(),
-                addressing_mode: self.addressing_mode,
-            };
-
-            for (address, color) in chunk {
-                fragment_command.key_colors.insert(**address, **color);
-            }
-
-            fragments.push(fragment_command);
-        }
-
-        fragments
+    if keys.is_empty() {
+        return vec![cmd.clone()];
     }
 
-    pub fn fragment_into_reports_optimized(&self) -> Vec<PerKeyRgbCommand> {
-        let mut fragments = Vec::new();
+    for chunk in keys.chunks(chunk_size) {
+        let mut fragment_command = PerKeyRgbCommand::new(cmd.addressing_mode);
 
-        if self.key_colors.is_empty() {
-            return vec![self.clone()];
+        for (address, color) in chunk {
+            fragment_command.key_colors.insert(**address, **color);
         }
 
-        let mut current_fragment = PerKeyRgbCommand {
-            key_colors: HashMap::with_capacity(Self::MAX_KEYS_PER_REPORT),
-            addressing_mode: self.addressing_mode,
-        };
-
-        for (address, color) in &self.key_colors {
-            current_fragment.key_colors.insert(*address, *color);
-
-            if current_fragment.key_colors.len() == Self::MAX_KEYS_PER_REPORT {
-                fragments.push(current_fragment);
-                current_fragment = PerKeyRgbCommand {
-                    key_colors: HashMap::with_capacity(Self::MAX_KEYS_PER_REPORT),
-                    addressing_mode: self.addressing_mode,
-                };
-            }
-        }
-
-        if !current_fragment.key_colors.is_empty() {
-            fragments.push(current_fragment);
-        }
-
-        fragments
+        fragments.push(fragment_command);
     }
+
+    fragments
 }
 
 fn main() {
-    let mut cmd = PerKeyRgbCommand {
-        key_colors: HashMap::new(),
-        addressing_mode: PerKeyAddressingMode::Matrix,
-    };
+    let mut cmd = PerKeyRgbCommand::new(PerKeyAddressingMode::HidCode);
 
     // Fill with 104 keys (standard full-size keyboard)
     for i in 0..104 {
-        let row = (i / 20) as u8;
-        let col = (i % 20) as u8;
         cmd.key_colors
-            .insert(KeyAddress { row, col }, Color { r: 255, g: 0, b: 0 });
+            .insert(KeyAddress::new(i), Color::RED);
     }
 
     let iterations = 100_000;
 
     let start = Instant::now();
     for _ in 0..iterations {
-        let _ = cmd.fragment_into_reports_original();
+        let _ = fragment_into_reports_original(&cmd);
     }
     let duration_original = start.elapsed();
 
     let start = Instant::now();
     for _ in 0..iterations {
-        let _ = cmd.fragment_into_reports_optimized();
+        let _ = cmd.fragment_into_reports();
     }
     let duration_optimized = start.elapsed();
 

--- a/src/bin/benchmark_fragment.rs
+++ b/src/bin/benchmark_fragment.rs
@@ -30,8 +30,7 @@ fn main() {
 
     // Fill with 104 keys (standard full-size keyboard)
     for i in 0..104 {
-        cmd.key_colors
-            .insert(KeyAddress::new(i), Color::RED);
+        cmd.key_colors.insert(KeyAddress::new(i), Color::RED);
     }
 
     let iterations = 100_000;


### PR DESCRIPTION
🎯 What: Refactored src/bin/benchmark_fragment.rs to import core data structures (like PerKeyRgbCommand, KeyAddress, Color) from the main steelseries_gg_linux crate instead of duplicating their definitions locally.
💡 Why: Having duplicate definitions in test/benchmark binaries makes the codebase harder to maintain and prone to drifting from the main library implementation over time.
✅ Verification: Ran `cargo test` and `cargo run --bin benchmark_fragment` to ensure that standard library functionalities behave identically and tests pass correctly.
✨ Result: Cleaned up redundant boilerplate in the benchmark tool while preserving its performance analysis functionality.

---
*PR created automatically by Jules for task [9111382516888788775](https://jules.google.com/task/9111382516888788775) started by @Ven0m0*