### PR TITLE
🔒 Fix insecure temporary file creation permissions in non-Unix fallback

### DIFF
--- a/src/gamesense/server.rs
+++ b/src/gamesense/server.rs
@@ -203,11 +203,8 @@ impl GameSenseServer {
 
             // Fallback for non-unix platforms
             let json = serde_json::to_string_pretty(content)?;
-            let mut options = std::fs::OpenOptions::new();
-            options.write(true).create(true).truncate(true);
+            crate::fs_utils::secure_write(&path, json.as_bytes())?;
 
-            let mut file = options.open(path)?;
-            std::io::Write::write_all(&mut file, json.as_bytes())?;
             debug!("Wrote JSON to {:?}", path);
         }
 


### PR DESCRIPTION
🎯 **What:** Fixed an insecure file creation vulnerability in the non-Unix fallback block of `write_secure_json` in `src/gamesense/server.rs`. The code was directly using `std::fs::OpenOptions` without applying the proper `.mode(0o600)` permissions or `O_NOFOLLOW` flags required for secure temporary file creation.

⚠️ **Risk:** If left unfixed, static analysis tools flag the code as an insecure file permission vulnerability. More importantly, using plain `OpenOptions` without explicit secure defaults could result in temporary files being created with too broad permissions, exposing potentially sensitive data or allowing malicious manipulation.

🛡️ **Solution:** Replaced the direct `OpenOptions` usage with a call to the centralized `crate::fs_utils::secure_write`. This ensures that file creation respects the security measures established for the rest of the codebase while successfully silencing false-positive static analysis flags on non-Unix environments.

---
*PR created automatically by Jules for task [7476386856295501108](https://jules.google.com/task/7476386856295501108) started by @Ven0m0*