### PR TITLE
🧹 Extract duplicated color arrays to shared constants

### DIFF
--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -830,16 +830,7 @@ impl Keyboard for GenericKeyboard {
             },
 
             PerKeyEffect::Spectrum { speed: _ } => ZoneEffect::Wave {
-                colors: vec![
-                    Color::RED,
-                    Color::ORANGE,
-                    Color::YELLOW,
-                    Color::GREEN,
-                    Color::CYAN,
-                    Color::BLUE,
-                    Color::PURPLE,
-                    Color::MAGENTA,
-                ],
+                colors: Color::RAINBOW_COLORS.to_vec(),
                 offset: 0.0,
             },
 

--- a/src/devices/zone_mapping.rs
+++ b/src/devices/zone_mapping.rs
@@ -503,16 +503,7 @@ impl ZoneFallback {
     pub fn pattern_to_zone_effect(&self, pattern: &str) -> Option<ZoneEffect> {
         match pattern.to_lowercase().as_str() {
             "rainbow" => Some(ZoneEffect::Wave {
-                colors: vec![
-                    Color::RED,
-                    Color::ORANGE,
-                    Color::YELLOW,
-                    Color::GREEN,
-                    Color::CYAN,
-                    Color::BLUE,
-                    Color::PURPLE,
-                    Color::MAGENTA,
-                ],
+                colors: Color::RAINBOW_COLORS.to_vec(),
                 offset: 0.0,
             }),
             "breathing" => Some(ZoneEffect::Breathing {

--- a/src/main.rs
+++ b/src/main.rs
@@ -830,15 +830,7 @@ async fn cmd_rgb(manager: &DeviceManager, action: RgbAction) -> Result<()> {
                 },
                 "spectrum" => Effect::Spectrum { speed },
                 "wave" => Effect::Wave {
-                    colors: vec![
-                        Color::RED,
-                        Color::ORANGE,
-                        Color::YELLOW,
-                        Color::GREEN,
-                        Color::CYAN,
-                        Color::BLUE,
-                        Color::PURPLE,
-                    ],
+                    colors: Color::DEFAULT_COLORS.to_vec(),
                     speed,
                     direction: WaveDirection::LeftToRight,
                 },
@@ -1104,16 +1096,7 @@ async fn cmd_per_key_rgb(keyboard: &mut Box<dyn Keyboard>, action: PerKeyAction)
 
 // Helper functions for pattern testing
 async fn test_rainbow_pattern(keyboard: &mut Box<dyn Keyboard>) -> Result<()> {
-    let colors = [
-        Color::RED,
-        Color::ORANGE,
-        Color::YELLOW,
-        Color::GREEN,
-        Color::CYAN,
-        Color::BLUE,
-        Color::PURPLE,
-        Color::MAGENTA,
-    ];
+    let colors = Color::RAINBOW_COLORS;
 
     if keyboard.supports_per_key_rgb() {
         // Use logical key mapping if available

--- a/src/rgb/mod.rs
+++ b/src/rgb/mod.rs
@@ -56,6 +56,29 @@ impl Color {
     /// Pink.
     pub const PINK: Color = Color::new(255, 105, 180);
 
+    /// Default 7-color sequence for wave effects.
+    pub const DEFAULT_COLORS: [Color; 7] = [
+        Color::RED,
+        Color::ORANGE,
+        Color::YELLOW,
+        Color::GREEN,
+        Color::CYAN,
+        Color::BLUE,
+        Color::PURPLE,
+    ];
+
+    /// Standard 8-color rainbow sequence.
+    pub const RAINBOW_COLORS: [Color; 8] = [
+        Color::RED,
+        Color::ORANGE,
+        Color::YELLOW,
+        Color::GREEN,
+        Color::CYAN,
+        Color::BLUE,
+        Color::PURPLE,
+        Color::MAGENTA,
+    ];
+
     /// Blend between two colors.
     #[inline]
     pub fn blend(a: Color, b: Color, t: f32) -> Color {


### PR DESCRIPTION
🎯 **What:** Extracted duplicated inline arrays of `Color` definitions into two shared constants: `Color::DEFAULT_COLORS` (7 colors) and `Color::RAINBOW_COLORS` (8 colors).
💡 **Why:** Reduces code duplication across the `src/main.rs`, `src/devices/keyboards/mod.rs`, and `src/devices/zone_mapping.rs` files, improving codebase maintainability.
✅ **Verification:** Verified changes by compiling and successfully running the complete test suite with `cargo test` and `cargo clippy`. Verified the replacement properly retained identical RGB effect patterns.
✨ **Result:** A cleaner codebase utilizing single sources of truth for common color gradients, completely satisfying the code health improvement requirements.

---
*PR created automatically by Jules for task [12133176296982851054](https://jules.google.com/task/12133176296982851054) started by @Ven0m0*