### PR TITLE
Optimize metrics export using async file I/O

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2823,7 +2823,8 @@ async fn cmd_verify_performance(
     if let Some(output_path) = output {
         let json = serde_json::to_string_pretty(&metrics)
             .map_err(|e| Error::Other(format!("Failed to serialize metrics: {}", e)))?;
-        secure_write(&output_path, json)
+        secure_write_async(output_path.clone(), json)
+            .await
             .map_err(|e| Error::Other(format!("Failed to write {}: {}", output_path, e)))?;
         println!("\nMetrics exported to: {}", output_path);
     }


### PR DESCRIPTION
💡 What: Replaced synchronous `secure_write` with asynchronous `secure_write_async` during JSON performance metric export.
🎯 Why: Prevents blocking the Tokio executor thread on potentially slow disk I/O when writing the metrics file.
📊 Measured Improvement: Eliminated synchronous I/O operations from the async context; avoids thread pool starvation.

---
*PR created automatically by Jules for task [9989433389897328163](https://jules.google.com/task/9989433389897328163) started by @Ven0m0*