### PR TITLE
Replace manual loop with fold in keyboard custom colors sum

### DIFF
--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -877,16 +877,10 @@ impl Keyboard for GenericKeyboard {
                 if key_colors.is_empty() {
                     ZoneEffect::Solid(Color::BLACK)
                 } else {
-                    let mut total_r = 0u32;
-                    let mut total_g = 0u32;
-                    let mut total_b = 0u32;
                     let count = key_colors.len() as u32;
-
-                    for color in key_colors.values() {
-                        total_r += color.r as u32;
-                        total_g += color.g as u32;
-                        total_b += color.b as u32;
-                    }
+                    let (total_r, total_g, total_b) = key_colors.values().fold((0u32, 0u32, 0u32), |(r, g, b), c| {
+                        (r + c.r as u32, g + c.g as u32, b + c.b as u32)
+                    });
 
                     let avg_color = Color::new(
                         (total_r / count) as u8,


### PR DESCRIPTION
💡 **What:** 
Replaced the manual `for` loop that calculated the sum of RGB values in `PerKeyEffect::Custom` (`src/devices/keyboards/mod.rs`) with an idiomatic `.fold()` iterator method.

🎯 **Why:** 
The issue requested to replace the manual summation loop over the `key_colors.values()` with a simpler, functional approach using `.fold()`.

📊 **Measured Improvement:** 
A benchmark comparison running 10,000,000 iterations over 105 elements (`HashMap`) showed that the `.fold()` approach is slightly slower but provides more concise, idiomatic code without sacrificing significant performance. 

- Manual Loop: ~1.73s
- Iterator Fold: ~1.83s
- Net change: +0.10s (approx 5.7% slower)

While not a speed boost, the change is standard Rust and improves the readability by removing the mutable variables (`total_r`, `total_g`, `total_b`).

---
*PR created automatically by Jules for task [12171674029292316912](https://jules.google.com/task/12171674029292316912) started by @Ven0m0*