### PR TITLE
performance-fix-async-io

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1967,8 +1967,9 @@ async fn cmd_performance(manager: &DeviceManager, action: PerformanceAction) -> 
                     "results": benchmark_results
                 });
 
-                secure_write(&output_path, serde_json::to_string_pretty(&benchmark_data)?)
-                    .map_err(|e| Error::DeviceCommunication(format!("Failed to write benchmark: {}", e)))?;
+                secure_write_async(output_path.clone(), serde_json::to_string_pretty(&benchmark_data)?)
+                    .await
+                    .map_err(|e| Error::FileSystemError(format!("Failed to write benchmark: {}", e)))?;
 
                 println!("📄 Benchmark results exported to: {}", output_path);
             }


### PR DESCRIPTION
💡 **What:** Replaced the synchronous `secure_write` call with `secure_write_async` in the `cmd_performance` function's benchmark export path.
🎯 **Why:** The Tokio async executor can become blocked if significant I/O operations are performed directly on it. This change offloads the filesystem operation using `tokio::task::spawn_blocking` (via `secure_write_async`), preventing thread starvation.
📊 **Measured Improvement:** The benchmark binary executes properly, completing an empty run in `~0.27s`. Because there are no physical keyboards attached in the testing environment, a full I/O saturation test cannot be directly benchmarked here. However, avoiding executor blocking is a foundational requirement for `tokio` correctness, preventing multi-millisecond latency spikes in concurrent network operations (like GameSense events) when large benchmark JSON strings are serialized and written.

---
*PR created automatically by Jules for task [13355814738262690365](https://jules.google.com/task/13355814738262690365) started by @Ven0m0*