### PR TITLE
perf/refactor: consolidate PRs #229–242 into one clean changeset

### DIFF
--- a/src/device_state.rs
+++ b/src/device_state.rs
@@ -171,13 +171,6 @@ pub struct DeviceState {
 #[serde(transparent)]
 struct SerializableStates(HashMap<String, DeviceState>);
 
-impl From<&HashMap<DeviceId, DeviceState>> for SerializableStates {
-    fn from(states: &HashMap<DeviceId, DeviceState>) -> Self {
-        let map = states.iter().map(|(id, state)| (id.to_key(), state.clone())).collect();
-        SerializableStates(map)
-    }
-}
-
 /// A zero-copy wrapper for serializing device states without cloning.
 struct SerializableStatesRef<'a>(&'a HashMap<DeviceId, DeviceState>);
 

--- a/src/devices/keyboards/mod.rs
+++ b/src/devices/keyboards/mod.rs
@@ -512,15 +512,9 @@ impl GenericKeyboard {
             return Color::BLACK;
         }
 
-        let mut total_r = 0u32;
-        let mut total_g = 0u32;
-        let mut total_b = 0u32;
-
-        for (_, color) in key_colors {
-            total_r += color.r as u32;
-            total_g += color.g as u32;
-            total_b += color.b as u32;
-        }
+        let (total_r, total_g, total_b) = key_colors.iter().fold((0u32, 0u32, 0u32), |(r, g, b), (_, color)| {
+            (r + color.r as u32, g + color.g as u32, b + color.b as u32)
+        });
 
         let count = key_colors.len() as u32;
         Color::new(
@@ -830,16 +824,7 @@ impl Keyboard for GenericKeyboard {
             },
 
             PerKeyEffect::Spectrum { speed: _ } => ZoneEffect::Wave {
-                colors: vec![
-                    Color::RED,
-                    Color::ORANGE,
-                    Color::YELLOW,
-                    Color::GREEN,
-                    Color::CYAN,
-                    Color::BLUE,
-                    Color::PURPLE,
-                    Color::MAGENTA,
-                ],
+                colors: Color::RAINBOW_COLORS.to_vec(),
                 offset: 0.0,
             },
 
@@ -877,16 +862,11 @@ impl Keyboard for GenericKeyboard {
                 if key_colors.is_empty() {
                     ZoneEffect::Solid(Color::BLACK)
                 } else {
-                    let mut total_r = 0u32;
-                    let mut total_g = 0u32;
-                    let mut total_b = 0u32;
+                    let (total_r, total_g, total_b) =
+                        key_colors.values().fold((0u32, 0u32, 0u32), |(r, g, b), color| {
+                            (r + color.r as u32, g + color.g as u32, b + color.b as u32)
+                        });
                     let count = key_colors.len() as u32;
-
-                    for color in key_colors.values() {
-                        total_r += color.r as u32;
-                        total_g += color.g as u32;
-                        total_b += color.b as u32;
-                    }
 
                     let avg_color = Color::new(
                         (total_r / count) as u8,

--- a/src/devices/zone_mapping.rs
+++ b/src/devices/zone_mapping.rs
@@ -503,16 +503,7 @@ impl ZoneFallback {
     pub fn pattern_to_zone_effect(&self, pattern: &str) -> Option<ZoneEffect> {
         match pattern.to_lowercase().as_str() {
             "rainbow" => Some(ZoneEffect::Wave {
-                colors: vec![
-                    Color::RED,
-                    Color::ORANGE,
-                    Color::YELLOW,
-                    Color::GREEN,
-                    Color::CYAN,
-                    Color::BLUE,
-                    Color::PURPLE,
-                    Color::MAGENTA,
-                ],
+                colors: Color::RAINBOW_COLORS.to_vec(),
                 offset: 0.0,
             }),
             "breathing" => Some(ZoneEffect::Breathing {

--- a/src/gamesense/server.rs
+++ b/src/gamesense/server.rs
@@ -26,13 +26,13 @@ type RgbCallback = Box<dyn Fn(&str, u8, u8, u8) + Send + Sync>;
 /// Shared server state.
 struct ServerState {
     /// Registered games - pre-allocate capacity for typical usage
-    games: HashMap<String, GameMetadata>,
+    games: HashMap<Arc<String>, GameMetadata>,
 
     /// Event bindings per game - use nested HashMap with better initial capacity
-    bindings: HashMap<String, HashMap<String, EventBinding>>,
+    bindings: HashMap<Arc<String>, HashMap<Arc<String>, EventBinding>>,
 
     /// Last event values - optimize for frequent access
-    event_values: HashMap<String, HashMap<String, i32>>,
+    event_values: HashMap<Arc<String>, HashMap<Arc<String>, i32>>,
 
     /// Callback for RGB updates.
     rgb_callback: Option<RgbCallback>,
@@ -203,11 +203,8 @@ impl GameSenseServer {
 
             // Fallback for non-unix platforms
             let json = serde_json::to_string_pretty(content)?;
-            let mut options = std::fs::OpenOptions::new();
-            options.write(true).create(true).truncate(true);
+            crate::fs_utils::secure_write(&path, json.as_bytes())?;
 
-            let mut file = options.open(path)?;
-            std::io::Write::write_all(&mut file, json.as_bytes())?;
             debug!("Wrote JSON to {:?}", path);
         }
 
@@ -291,7 +288,7 @@ async fn register_game(
 
     info!("Registering game: {} ({})", metadata.game_display_name, metadata.game);
 
-    state.games.insert(metadata.game.clone(), metadata);
+    state.games.insert(Arc::new(metadata.game.clone()), metadata);
 
     (StatusCode::OK, Json(ApiResponse::success()))
 }
@@ -305,8 +302,22 @@ async fn bind_event(
 
     debug!("Binding event: {}:{}", binding.game, binding.event);
 
-    let game_bindings = state.bindings.entry(binding.game.clone()).or_default();
-    game_bindings.insert(binding.event.clone(), binding);
+    // Reuse existing Arc<String> keys to avoid allocations on hot paths
+    let game_key = state
+        .games
+        .get_key_value(&binding.game)
+        .map(|(k, _)| Arc::clone(k))
+        .or_else(|| state.bindings.get_key_value(&binding.game).map(|(k, _)| Arc::clone(k)))
+        .unwrap_or_else(|| Arc::new(binding.game.clone()));
+
+    let game_bindings = state.bindings.entry(game_key).or_default();
+
+    let event_key = game_bindings
+        .get_key_value(&binding.event)
+        .map(|(k, _)| Arc::clone(k))
+        .unwrap_or_else(|| Arc::new(binding.event.clone()));
+
+    game_bindings.insert(event_key, binding);
 
     (StatusCode::OK, Json(ApiResponse::success()))
 }
@@ -318,11 +329,22 @@ async fn game_event(State(state): State<AppState>, Json(event): Json<GameEvent>)
     // Store the event value with write lock (brief critical section)
     {
         let mut state_write = state.write();
-        state_write
-            .event_values
-            .entry(event.game.clone())
-            .or_default()
-            .insert(event.event.clone(), event.data.value);
+
+        let game_key = state_write
+            .bindings
+            .get_key_value(&event.game)
+            .map(|(k, _)| Arc::clone(k))
+            .or_else(|| state_write.games.get_key_value(&event.game).map(|(k, _)| Arc::clone(k)))
+            .unwrap_or_else(|| Arc::new(event.game.clone()));
+
+        let game_events = state_write.event_values.entry(game_key).or_default();
+
+        let event_key = game_events
+            .get_key_value(&event.event)
+            .map(|(k, _)| Arc::clone(k))
+            .unwrap_or_else(|| Arc::new(event.event.clone()));
+
+        game_events.insert(event_key, event.data.value);
     } // Write lock released here
 
     // Process handlers with read lock to allow concurrent event handling

--- a/src/main.rs
+++ b/src/main.rs
@@ -830,15 +830,7 @@ async fn cmd_rgb(manager: &DeviceManager, action: RgbAction) -> Result<()> {
                 },
                 "spectrum" => Effect::Spectrum { speed },
                 "wave" => Effect::Wave {
-                    colors: vec![
-                        Color::RED,
-                        Color::ORANGE,
-                        Color::YELLOW,
-                        Color::GREEN,
-                        Color::CYAN,
-                        Color::BLUE,
-                        Color::PURPLE,
-                    ],
+                    colors: Color::DEFAULT_COLORS.to_vec(),
                     speed,
                     direction: WaveDirection::LeftToRight,
                 },
@@ -1104,16 +1096,7 @@ async fn cmd_per_key_rgb(keyboard: &mut Box<dyn Keyboard>, action: PerKeyAction)
 
 // Helper functions for pattern testing
 async fn test_rainbow_pattern(keyboard: &mut Box<dyn Keyboard>) -> Result<()> {
-    let colors = [
-        Color::RED,
-        Color::ORANGE,
-        Color::YELLOW,
-        Color::GREEN,
-        Color::CYAN,
-        Color::BLUE,
-        Color::PURPLE,
-        Color::MAGENTA,
-    ];
+    let colors = Color::RAINBOW_COLORS;
 
     if keyboard.supports_per_key_rgb() {
         // Use logical key mapping if available
@@ -1828,7 +1811,7 @@ async fn cmd_performance(manager: &DeviceManager, action: PerformanceAction) -> 
                     display_performance_stats(manager, &keyboards, json)?;
 
                     if let Some(ref output_path) = output {
-                        export_performance_stats(manager, &keyboards, output_path, json)?;
+                        export_performance_stats(manager, &keyboards, output_path, json).await?;
                     }
 
                     tokio::time::sleep(Duration::from_secs(interval_seconds)).await;
@@ -1837,7 +1820,7 @@ async fn cmd_performance(manager: &DeviceManager, action: PerformanceAction) -> 
                 display_performance_stats(manager, &keyboards, json)?;
 
                 if let Some(output_path) = output {
-                    export_performance_stats(manager, &keyboards, &output_path, json)?;
+                    export_performance_stats(manager, &keyboards, &output_path, json).await?;
                     println!("📄 Performance stats exported to: {}", output_path);
                 }
             }
@@ -1980,19 +1963,33 @@ async fn cmd_performance(manager: &DeviceManager, action: PerformanceAction) -> 
     Ok(())
 }
 
-fn display_performance_stats(manager: &DeviceManager, keyboards: &[&DeviceInfo], json: bool) -> Result<()> {
-    if json {
-        let mut all_stats = HashMap::new();
+struct StatsMapSerializer<'a> {
+    manager: &'a DeviceManager,
+    keyboards: &'a [&'a DeviceInfo],
+}
 
-        for device_info in keyboards {
-            if let Ok(keyboard) = manager.open_keyboard(device_info) {
+impl<'a> serde::Serialize for StatsMapSerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        for device_info in self.keyboards {
+            if let Ok(keyboard) = self.manager.open_keyboard(device_info) {
                 if let Some(stats) = keyboard.get_rgb_performance_stats() {
-                    all_stats.insert(device_info.name.to_string(), stats.clone());
+                    map.serialize_entry(&device_info.name, stats)?;
                 }
             }
         }
+        map.end()
+    }
+}
 
-        println!("{}", serde_json::to_string_pretty(&all_stats)?);
+fn display_performance_stats(manager: &DeviceManager, keyboards: &[&DeviceInfo], json: bool) -> Result<()> {
+    if json {
+        let stats_map = StatsMapSerializer { manager, keyboards };
+        println!("{}", serde_json::to_string_pretty(&stats_map)?);
     } else {
         println!("📊 RGB Performance Statistics:");
         println!();
@@ -2033,30 +2030,22 @@ fn display_performance_stats(manager: &DeviceManager, keyboards: &[&DeviceInfo],
     Ok(())
 }
 
-fn export_performance_stats(
+async fn export_performance_stats(
     manager: &DeviceManager,
     keyboards: &[&DeviceInfo],
     output_path: &str,
     json: bool,
 ) -> Result<()> {
     if json {
-        let mut all_stats = HashMap::new();
-
-        for device_info in keyboards {
-            if let Ok(keyboard) = manager.open_keyboard(device_info) {
-                if let Some(stats) = keyboard.get_rgb_performance_stats() {
-                    all_stats.insert(device_info.name.to_string(), stats.clone());
-                }
-            }
-        }
-
+        let stats_map = StatsMapSerializer { manager, keyboards };
         let export_data = serde_json::json!({
             "timestamp": chrono::Utc::now().to_rfc3339(),
-            "devices": all_stats
+            "devices": stats_map
         });
 
-        secure_write(output_path, serde_json::to_string_pretty(&export_data)?)
-            .map_err(|e| Error::DeviceCommunication(format!("Failed to write stats: {}", e)))?;
+        secure_write_async(output_path.to_string(), serde_json::to_string_pretty(&export_data)?)
+            .await
+            .map_err(|e| Error::FileSystemError(format!("Failed to write stats: {}", e)))?;
     } else {
         let mut content = String::new();
         content.push_str("# RGB Performance Statistics Report\n\n");
@@ -2091,8 +2080,9 @@ fn export_performance_stats(
             }
         }
 
-        secure_write(output_path, content)
-            .map_err(|e| Error::DeviceCommunication(format!("Failed to write stats: {}", e)))?;
+        secure_write_async(output_path.to_string(), content)
+            .await
+            .map_err(|e| Error::FileSystemError(format!("Failed to write stats: {}", e)))?;
     }
 
     Ok(())
@@ -2194,36 +2184,8 @@ impl DaemonState {
                             }
                         } else if let Some(ref profile_manager) = self.profile_manager {
                             // Try to apply default profile
-                            if let Some(default_profile) = profile_manager.get("default") {
-                                if let Some(ref keyboard_profile) = default_profile.keyboard {
-                                    rgb_controller.set_effect(keyboard_profile.effect.clone());
-                                    rgb_controller.set_brightness(keyboard_profile.brightness as f32 / 100.0);
-
-                                    match &keyboard_profile.effect {
-                                        Effect::Static { color } => {
-                                            if let Err(e) = keyboard.set_color(*color).await {
-                                                warn!("Failed to apply default profile color to {}: {}", info.name, e);
-                                            }
-                                        }
-                                        Effect::Off => {
-                                            if let Err(e) = keyboard.set_color(Color::BLACK).await {
-                                                warn!("Failed to turn off {} (default profile): {}", info.name, e);
-                                            }
-                                        }
-                                        _ => {
-                                            info!(
-                                                "Applied default animated profile for {} (will be handled by animation loop)",
-                                                info.name
-                                            );
-                                        }
-                                    }
-
-                                    info!(
-                                        "Applied default profile to {}: brightness={}%, effect={:?}",
-                                        info.name, keyboard_profile.brightness, keyboard_profile.effect
-                                    );
-                                }
-                            }
+                            Self::apply_default_profile(profile_manager, keyboard.as_mut(), &mut rgb_controller, info)
+                                .await;
                         }
 
                         // Store device information
@@ -2268,6 +2230,47 @@ impl DaemonState {
         }
 
         Ok(())
+    }
+
+    async fn apply_default_profile(
+        profile_manager: &ProfileManager,
+        keyboard: &mut dyn Keyboard,
+        rgb_controller: &mut RgbController,
+        info: &DeviceInfo,
+    ) {
+        let Some(default_profile) = profile_manager.get("default") else {
+            return;
+        };
+        let Some(ref keyboard_profile) = default_profile.keyboard else {
+            return;
+        };
+
+        rgb_controller.set_effect(keyboard_profile.effect.clone());
+        rgb_controller.set_brightness(keyboard_profile.brightness as f32 / 100.0);
+
+        match &keyboard_profile.effect {
+            Effect::Static { color } => {
+                if let Err(e) = keyboard.set_color(*color).await {
+                    warn!("Failed to apply default profile color to {}: {}", info.name, e);
+                }
+            }
+            Effect::Off => {
+                if let Err(e) = keyboard.set_color(Color::BLACK).await {
+                    warn!("Failed to turn off {} (default profile): {}", info.name, e);
+                }
+            }
+            _ => {
+                info!(
+                    "Applied default animated profile for {} (will be handled by animation loop)",
+                    info.name
+                );
+            }
+        }
+
+        info!(
+            "Applied default profile to {}: brightness={}%, effect={:?}",
+            info.name, keyboard_profile.brightness, keyboard_profile.effect
+        );
     }
 
     /// Get current device count for monitoring
@@ -3169,17 +3172,17 @@ async fn run_animation_loop(daemon_state_anim: Arc<RwLock<DaemonState>>) {
             // First, remove the keyboard entry from the map while holding the lock
             let keyboard_entry = {
                 let mut state = daemon_state_anim.write().await;
-                state.keyboards.remove(serial.as_str())
+                state.keyboards.remove_entry(serial.as_str())
             };
 
-            if let Some((mut keyboard, controller, other)) = keyboard_entry {
+            if let Some((owned_serial, (mut keyboard, controller, other))) = keyboard_entry {
                 if let Err(e) = keyboard.set_zone_colors(colors).await {
                     tracing::warn!("Failed to update keyboard {}: {}", serial, e);
                 }
 
                 // Reinsert the keyboard entry after the async operation completes
                 let mut state = daemon_state_anim.write().await;
-                state.keyboards.insert(serial.clone(), (keyboard, controller, other));
+                state.keyboards.insert(owned_serial, (keyboard, controller, other));
             }
         }
 

--- a/src/rgb/mod.rs
+++ b/src/rgb/mod.rs
@@ -56,6 +56,29 @@ impl Color {
     /// Pink.
     pub const PINK: Color = Color::new(255, 105, 180);
 
+    /// Default 7-color sequence for wave effects.
+    pub const DEFAULT_COLORS: [Color; 7] = [
+        Color::RED,
+        Color::ORANGE,
+        Color::YELLOW,
+        Color::GREEN,
+        Color::CYAN,
+        Color::BLUE,
+        Color::PURPLE,
+    ];
+
+    /// Standard 8-color rainbow sequence.
+    pub const RAINBOW_COLORS: [Color; 8] = [
+        Color::RED,
+        Color::ORANGE,
+        Color::YELLOW,
+        Color::GREEN,
+        Color::CYAN,
+        Color::BLUE,
+        Color::PURPLE,
+        Color::MAGENTA,
+    ];
+
     /// Blend between two colors.
     #[inline]
     pub fn blend(a: Color, b: Color, t: f32) -> Color {
@@ -643,18 +666,26 @@ impl PerKeyEffectEngine {
         // cleanly without clearing the map or duplicating logic.
         if self.cached_key_colors.is_empty() {
             // First run: Iterate all keys from mapping and populate
-            let mut new_colors = HashMap::with_capacity(self.key_mapping.total_keys);
-            for key in self.key_mapping.get_all_keys() {
-                let mut color = Color::BLACK;
-                Self::apply_effect_static(
-                    &self.effect,
-                    *key,
-                    &mut color,
-                    &self.key_mapping,
-                    &self.reactive_state,
-                    elapsed_secs,
-                );
-                new_colors.insert(*key, color);
+            let keys = self.key_mapping.get_all_keys();
+            let mut new_colors = HashMap::with_capacity(keys.len());
+
+            if let PerKeyEffect::Static { color } = self.effect {
+                for key in keys {
+                    new_colors.insert(*key, color);
+                }
+            } else {
+                for key in keys {
+                    let mut color = Color::BLACK;
+                    Self::apply_effect_static(
+                        &self.effect,
+                        *key,
+                        &mut color,
+                        &self.key_mapping,
+                        &self.reactive_state,
+                        elapsed_secs,
+                    );
+                    new_colors.insert(*key, color);
+                }
             }
             self.cached_key_colors = new_colors;
         } else {


### PR DESCRIPTION
## Summary

Consolidates all 14 open PRs (#229–242) into a single clean, non-conflicting commit. Duplicate PRs targeting the same change (async I/O: #233/#234/#236; fold loops: #235/#239) were resolved by taking the most complete implementation. Noise artifacts from PR #241 (`submit.sh`, `test.sh`, `criterion` dev-dependency) are excluded.

### Changes included

| Area | Change | Source PR(s) |
|------|--------|-------------|
| `src/rgb/mod.rs` | Add `Color::DEFAULT_COLORS` and `Color::RAINBOW_COLORS` constants | #232 |
| `src/rgb/mod.rs` | Fast path for `PerKeyEffect::Static` on first-run key-color population | #242 |
| `src/devices/keyboards/mod.rs` | Replace manual accumulator loops with `.fold()` in both `compute_average_color` and `PerKeyEffect::Custom` | #239 (supersedes #235) |
| `src/devices/keyboards/mod.rs`, `src/devices/zone_mapping.rs`, `src/main.rs` | Replace duplicated inline color arrays with `Color::RAINBOW_COLORS`/`Color::DEFAULT_COLORS` | #232 |
| `src/main.rs` | Extract `DaemonState::apply_default_profile` to flatten arrow-pattern nesting | #229 |
| `src/main.rs` | Use `remove_entry` in animation loop to reuse owned key `String` on HashMap reinsert | #230 |
| `src/main.rs` | `StatsMapSerializer`: serialize perf stats directly into JSON without an intermediate `HashMap` | #238 |
| `src/main.rs` | Make `export_performance_stats` `async`; replace `secure_write` with `secure_write_async` | #237 (supersedes #233/#234/#236) |
| `src/gamesense/server.rs` | Change `ServerState` HashMap keys to `Arc<String>`; reuse existing `Arc` on hot paths | #241 |
| `src/gamesense/server.rs` | Fix non-Unix fallback in `write_secure_json` to use `crate::fs_utils::secure_write` | #231 |
| `src/device_state.rs` | Remove dead `SerializableStates::from` impl that cloned the entire device-state map | #240 |

## Test plan

- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy --all-targets --locked -- -D warnings` — no warnings
- [x] `cargo test --locked` — all tests pass
- [x] `cargo check --locked` — clean compile

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2vgqmwdxbxxpmzgNGvK3X)_