### PR TITLE
Allow manual release trigger via workflow_dispatch with version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 # Triggered by pushing a semver tag: git tag v1.2.3 && git push origin v1.2.3
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (without leading v, e.g. 0.1.0)'
+        required: true
+        type: string
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -31,14 +36,18 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing v$VERSION"
 
       - name: Verify Cargo.toml version matches tag
         run: |
           CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${{ steps.version.outputs.version }}"
           if [[ "$CARGO_VERSION" != "$TAG_VERSION" ]]; then
             echo "::error::Cargo.toml version ($CARGO_VERSION) does not match tag ($TAG_VERSION)"
             exit 1
@@ -47,7 +56,7 @@ jobs:
       - name: Extract changelog section
         id: notes
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ steps.version.outputs.version }}"
           # Extract everything between ## [VERSION] and the next ## [
           NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
           if [[ -z "$NOTES" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,33 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing v$VERSION"
 
+      - name: Create tag if missing
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+          # Check if the tag already exists on the remote
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/git/ref/tags/${TAG}")
+          if [[ "$STATUS" == "200" ]]; then
+            echo "Tag $TAG already exists — skipping creation"
+          else
+            SHA=$(curl -s \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}" \
+              | jq -r '.sha')
+            curl -s -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.github.com/repos/${{ github.repository }}/git/refs" \
+              -d "{\"ref\":\"refs/tags/${TAG}\",\"sha\":\"${SHA}\"}" \
+              | jq .
+            echo "Created tag $TAG at $SHA"
+          fi
+
       - name: Verify Cargo.toml version matches tag
         run: |
           CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
@@ -200,7 +227,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: "v${{ needs.prepare.outputs.version }}"
-          tag_name: ${{ github.ref_name }}
+          tag_name: "v${{ needs.prepare.outputs.version }}"
           body: |
             ## What's Changed
 
@@ -211,4 +238,4 @@ jobs:
           files: dist/*
           fail_on_unmatched_files: true
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(needs.prepare.outputs.version, '-') }}


### PR DESCRIPTION
## Summary

Enhance the release workflow to support manual triggering via `workflow_dispatch`, allowing releases to be initiated without pushing a git tag. This provides flexibility for releasing from any commit while maintaining version consistency checks.

## Key Changes

- **Added `workflow_dispatch` input**: New `version` input parameter (required, string format) accepts the version to release without the leading `v` prefix (e.g., `0.1.0`)
- **Dynamic version resolution**: Updated the "Resolve version" step to check the trigger event type and use either the workflow input or the git tag name
- **Automatic tag creation**: New "Create tag if missing" step that:
  - Checks if the tag already exists on the remote via GitHub API
  - Creates the tag at the current commit SHA if it doesn't exist
  - Skips creation if the tag is already present
- **Consistent version references**: Replaced hardcoded `GITHUB_REF_NAME` references with the resolved version output throughout the workflow to ensure consistency between manual and tag-triggered releases
- **Fixed release metadata**: Updated the `action-gh-release` step to use the resolved version for both `tag_name` and `prerelease` detection, ensuring manual releases are tagged and classified correctly

## Implementation Details

The version resolution logic prioritizes the workflow input when triggered manually, falling back to extracting the version from the git tag name for push-triggered releases. The tag creation step uses the GitHub API to safely handle both new and existing tags, preventing errors when a tag is already present on the remote.

All version-dependent steps now reference `steps.version.outputs.version` rather than `GITHUB_REF_NAME`, ensuring the release process works consistently regardless of trigger method.

https://claude.ai/code/session_01DmogdRuEwv78NVe4WuQVve