### PR TITLE
Integrate prek.toml hooks into .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,12 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: check-added-large-files
       - id: check-case-conflict
       - id: check-executables-have-shebangs
-      - id: check-merge-conflict
       - id: check-json
+      - id: check-merge-conflict
+      - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -16,3 +18,18 @@ repos:
       - id: check-dependabot
       - id: check-github-actions
       - id: check-github-workflows
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]


### PR DESCRIPTION
## Summary

- Adds `check-added-large-files` and `check-toml` to the `pre-commit-hooks` repo (both present in `prek.toml` but missing from the YAML)
- Adds a `local` repo section with `cargo-fmt` (runs on every commit) and `cargo-clippy` (runs on `pre-push` only), mirroring the local hooks in `prek.toml`

## Test plan

- [ ] Run `pre-commit run --all-files` and confirm all hooks pass
- [ ] Verify `cargo-clippy` fires on `git push` but not on `git commit`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChNfaHpjC78JQ2NfYXft7j)_