### PR TITLE
ci(release): consolidate Arch Linux build into Linux workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,4 +1,4 @@
-name: Build Arch Linux
+name: Build Linux / Arch
 
 on:
   workflow_dispatch:
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  build-arch:
-    name: Build Arch Linux Package
+  build-linux:
+    name: Build Linux / Arch x86_64
     runs-on: ubuntu-latest
     container:
       image: archlinux:base-devel
@@ -34,7 +34,7 @@ jobs:
           echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown -R builder:builder .
 
-      - name: Build Arch package
+      - name: Build via PKGBUILD
         env:
           EXTRA_FEATURES: ${{ github.event.inputs.features }}
         run: |
@@ -51,16 +51,23 @@ jobs:
           gzip -n "ssgg-${PKGVER}.tar"
           su - builder -c "cd \"$GITHUB_WORKSPACE\" && SRCDEST=\"$GITHUB_WORKSPACE\" makepkg -sCf --noconfirm"
 
+      - name: Package generic Linux binary
+        run: tar -C src/target/release -czf ssgg-linux-x86_64.tar.gz ssgg
+
       - name: Compute checksums
         run: |
-          sha256sum *.pkg.tar.zst > sha256sums.txt
-          cat sha256sums.txt
+          sha256sum ssgg-linux-x86_64.tar.gz > sha256sums-linux.txt
+          sha256sum *.pkg.tar.zst > sha256sums-arch.txt
+          cat sha256sums-linux.txt
+          cat sha256sums-arch.txt
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ssgg-arch-x86_64
+          name: ssgg-linux-x86_64
           path: |
+            ssgg-linux-x86_64.tar.gz
+            sha256sums-linux.txt
             *.pkg.tar.zst
-            sha256sums.txt
+            sha256sums-arch.txt
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
-# Builds release binaries for Linux, Windows, and Arch Linux and uploads them
-# as assets on the GitHub Release that release-please creates for a v* tag.
-# Versioning and CHANGELOG.md are managed by release-please
+# Builds release binaries for Linux (generic + Arch package) and Windows, then
+# uploads them as assets on the GitHub Release that release-please creates for
+# a v* tag.  Versioning and CHANGELOG.md are managed by release-please
 # (.github/workflows/release-please.yml); this workflow only produces and
 # uploads artifacts.
 
@@ -20,30 +20,51 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Linux x86_64 (GNU)
+  # Linux x86_64 (generic binary + Arch package via PKGBUILD)
   # ---------------------------------------------------------------------------
   build-linux:
-    name: Build Linux x86_64
+    name: Build Linux / Arch x86_64
     runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
 
     steps:
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --needed --noconfirm git rust systemd
+
       - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.94.1
-          targets: x86_64-unknown-linux-gnu
+          fetch-depth: 0
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Create unprivileged build user
+        run: |
+          useradd -m builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          chown -R builder:builder .
 
-      - name: Build release binary
-        run: cargo build --release --locked --target x86_64-unknown-linux-gnu
+      - name: Build via PKGBUILD
+        run: |
+          PKGVER=$(sed -n 's/^pkgver=\([^ ]*\).*/\1/p' PKGBUILD | head -n1)
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git archive \
+            --format=tar \
+            --prefix="steelseriesgg-rs-${PKGVER}/" \
+            --output="ssgg-${PKGVER}.tar" \
+            HEAD
+          gzip -n "ssgg-${PKGVER}.tar"
+          su - builder -c "cd \"$GITHUB_WORKSPACE\" && SRCDEST=\"$GITHUB_WORKSPACE\" makepkg -sCf --noconfirm"
 
-      - name: Package binary
-        run: tar -C target/x86_64-unknown-linux-gnu/release -czf ssgg-linux-x86_64.tar.gz ssgg
+      - name: Package generic Linux binary
+        run: tar -C src/target/release -czf ssgg-linux-x86_64.tar.gz ssgg
 
       - name: Compute SHA-256
-        run: sha256sum ssgg-linux-x86_64.tar.gz > sha256sums-linux.txt
+        run: |
+          sha256sum ssgg-linux-x86_64.tar.gz > sha256sums-linux.txt
+          sha256sum *.pkg.tar.zst > sha256sums-arch.txt
+          cat sha256sums-linux.txt
+          cat sha256sums-arch.txt
 
       - name: Upload to release
         if: startsWith(github.ref, 'refs/tags/')
@@ -52,6 +73,8 @@ jobs:
           files: |
             ssgg-linux-x86_64.tar.gz
             sha256sums-linux.txt
+            *.pkg.tar.zst
+            sha256sums-arch.txt
 
   # ---------------------------------------------------------------------------
   # Windows x86_64 (MSVC)
@@ -88,53 +111,3 @@ jobs:
           files: |
             ssgg-windows-x86_64.exe
             sha256sums-windows.txt
-
-  # ---------------------------------------------------------------------------
-  # Arch Linux .pkg.tar.zst
-  # ---------------------------------------------------------------------------
-  build-arch:
-    name: Build Arch Linux Package
-    runs-on: ubuntu-latest
-    container:
-      image: archlinux:base-devel
-
-    steps:
-      - name: Install dependencies
-        run: |
-          pacman -Syu --noconfirm
-          pacman -S --needed --noconfirm git rust systemd
-
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Create unprivileged build user
-        run: |
-          useradd -m builder
-          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-          chown -R builder:builder .
-
-      - name: Build Arch package
-        run: |
-          PKGVER=$(sed -n 's/^pkgver=\([^ ]*\).*/\1/p' PKGBUILD | head -n1)
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git archive \
-            --format=tar \
-            --prefix="steelseriesgg-rs-${PKGVER}/" \
-            --output="ssgg-${PKGVER}.tar" \
-            HEAD
-          gzip -n "ssgg-${PKGVER}.tar"
-          su - builder -c "cd \"$GITHUB_WORKSPACE\" && SRCDEST=\"$GITHUB_WORKSPACE\" makepkg -sCf --noconfirm"
-
-      - name: Compute checksums
-        run: |
-          sha256sum *.pkg.tar.zst > sha256sums-arch.txt
-          cat sha256sums-arch.txt
-
-      - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            *.pkg.tar.zst
-            sha256sums-arch.txt


### PR DESCRIPTION
Integrate the Arch Linux package build process into the main release workflow to streamline artifact generation.

Changes:
- Remove standalone  workflow
- Update  to use  container for the  job
- Add new  workflow for generic Linux builds with PKGBUILD
- Upload both generic Linux binary tarball and Arch package  with checksums

This consolidates the separate Ubuntu-based Linux build and Arch container build into a single PKGBUILD-based workflow that produces both artifacts.